### PR TITLE
Piper/add black code formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
   pypy3-core:
     <<: *common
     docker:
@@ -74,4 +80,5 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core
       - pypy3-core

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ lint:
 	tox -elint
 
 lint-roll:
-	isort --recursive eth_enr tests
+	isort eth_enr tests
+	black eth_enr tests
 	$(MAKE) lint
 
 test:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 
 [pytest-watch]

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,16 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==5.4.1",
-        "pytest-xdist",
-        "tox==3.14.6",
+        "pytest==6.0.1",
+        "pytest-xdist==2.1.0",
+        "tox==3.19.0",
     ],
     'lint': [
-        "flake8==3.7.9",
-        "isort>=4.2.15,<5",
-        "mypy==0.770",
+        "flake8==3.8.3",
+        "isort==5.4.2",
+        "mypy==0.782",
         "pydocstyle>=3.0.0,<4",
+        "black==20.8b1",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",
@@ -72,6 +73,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,4 +1,2 @@
-
-
 def test_import():
     import eth_enr  # noqa: F401

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
 envlist=
-    py{36,37,py3}-core
+    py{36,37,38,py3}-core
     lint
     docs
 
 [isort]
-combine_as_imports=True
+force_grid_wrap=0
 force_sort_within_sections=True
 include_trailing_comma=True
-known_third_party=hypothesis,pytest
 known_first_party=eth_enr
-line_length=21
+known_third_party=pytest,eth_utils
+line_length=88
 multi_line_output=3
 use_parentheses=True
 
@@ -28,6 +28,7 @@ basepython =
     docs: python
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy3: pypy3
 extras=
     test
@@ -40,5 +41,6 @@ extras=lint
 commands=
     mypy -p {toxinidir}/eth_enr --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/eth_enr {toxinidir}/tests
-    isort --recursive --check-only --diff {toxinidir}/eth_enr {toxinidir}/tests
+    isort --check-only --diff {toxinidir}/eth_enr {toxinidir}/tests
+    black --check --diff {toxinidir}/eth_enr/ --check --diff {toxinidir}/tests/
     pydocstyle {toxinidir}/eth_enr {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

Outdated testing deps as well as testing/support for python3.8

## How was it fixed?

- Added 3.8 env
- updated requirements
- added `black`

#### Cute Animal Picture

![7a4120f095480e9f2a2ad2a165d90313](https://user-images.githubusercontent.com/824194/91776703-27ed0080-ebab-11ea-8729-8a19bb225915.jpg)

