### PR TITLE
Use NodeID from eth-typing

### DIFF
--- a/eth_enr/abc.py
+++ b/eth_enr/abc.py
@@ -2,7 +2,9 @@ from abc import ABC, abstractmethod
 from collections import UserDict
 from typing import TYPE_CHECKING, Any, Mapping, Type
 
-from eth_enr.typing import ENR_KV, NodeID
+from eth_typing import NodeID
+
+from eth_enr.typing import ENR_KV
 
 # https://github.com/python/mypy/issues/5264#issuecomment-399407428
 if TYPE_CHECKING:

--- a/eth_enr/enr.py
+++ b/eth_enr/enr.py
@@ -2,6 +2,7 @@ import base64
 import operator
 from typing import AbstractSet, Any, Iterator, Mapping, Tuple, Type, ValuesView
 
+from eth_typing import NodeID
 from eth_utils import ValidationError
 import rlp
 
@@ -18,7 +19,6 @@ from eth_enr.identity_schemes import (
 )
 from eth_enr.identity_schemes import IdentitySchemeRegistry
 from eth_enr.sedes import ENRContentSedes, ENRSedes
-from eth_enr.typing import NodeID
 
 
 class ENRCommon(CommonENRAPI):

--- a/eth_enr/identity_schemes.py
+++ b/eth_enr/identity_schemes.py
@@ -3,6 +3,7 @@ from typing import Type
 from eth_keys.datatypes import NonRecoverableSignature, PrivateKey, PublicKey
 from eth_keys.exceptions import BadSignature
 from eth_keys.exceptions import ValidationError as EthKeysValidationError
+from eth_typing import NodeID
 from eth_utils import ValidationError, encode_hex, keccak
 
 from eth_enr.abc import (
@@ -11,7 +12,6 @@ from eth_enr.abc import (
     IdentitySchemeAPI,
     IdentitySchemeRegistryAPI,
 )
-from eth_enr.typing import NodeID
 
 
 class IdentitySchemeRegistry(IdentitySchemeRegistryAPI):

--- a/eth_enr/typing.py
+++ b/eth_enr/typing.py
@@ -1,5 +1,3 @@
-from typing import NewType, Tuple, Union
-
-NodeID = NewType("NodeID", bytes)
+from typing import Tuple, Union
 
 ENR_KV = Tuple[bytes, Union[int, bytes]]

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "eth-hash[pycryptodome]>=0.1.4,<1",
         "eth-keys>=0.3.3,<0.4.0",
         "eth-utils>=1,<2",
+        "eth-typing>=2.2.2,<3",
         "rlp>=1.1.0,<2.0.0",
     ],
     python_requires='>=3.6, <4',


### PR DESCRIPTION
## What was wrong?

New `eth_typing.NodeID` type that we can use

## How was it fixed?

Updated to use it.

#### Cute Animal Picture

![This-giraffe-seems-to-be-pretty-confused-as-well-600x590](https://user-images.githubusercontent.com/824194/92054464-4b4eb180-ed4b-11ea-9baa-1b750bd73fee.jpg)
