### PR TITLE
Add ENRDatabaseAPI

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,8 @@
 API
 ===
 
-Library
--------
+Abstract Base Classes
+---------------------
 
 .. autoclass:: eth_enr.abc.CommonENRAPI
     :members:
@@ -35,6 +35,51 @@ Library
 
 
 .. autoclass:: eth_enr.abc.IdentitySchemeRegistryAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Classes
+-------
+
+.. autoclass:: eth_enr.enr.ENR
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.enr.UnsignedENR
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.enr_db.ENRDB
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.enr_manager.ENRManager
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.identity_schemes.IdentitySchemeRegistry
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.identity_schemes.V4IdentityScheme
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.identity_schemes.V4CompatIdentityScheme
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,39 +1,42 @@
 Quickstart
 ==========
 
-Simple ENR Creation
--------------------
 
-Creating your first ENR record is as simple as:
+ENR Creation
+------------
+
+You can create an ENR record as follows.
+
 
 .. doctest::
 
     >>> from eth_keys import keys
-    >>> from eth_enr import ENRManager
+    >>> from eth_enr import UnsignedENR, ENR
     >>> private_key = keys.PrivateKey(b'unicornsrainbowsunicornsrainbows')
-    >>> manager = ENRManager(private_key)
-    >>> manager.enr
-    enr:-HW4QDBN_uzB2BgXNgpjCN83hSE13oI46ZtFOmWnmYkGTZWrfRF6Yk60HcoiyuLDXqCTcj8fqk2DWetU2ZYJrXUEylIBgmlkgnY0iXNlY3AyNTZrMaEDvfDdonz3wUFd66sirz_3a0oRlsc9rlKp0SQeHEkcC6g
-    >>> manager.enr.sequence_number
-    1
-    >>> manager.update((b'foo', b'bar'))
-    enr:-H24QNUv1DBIpMITIUjJN8s7foWBJ33rR0liWCu4nVDaXk7ACcXpiMiFJHPC8UKTNkXfN3DXGwPX-Q6KL1uMZwNeyGMCg2Zvb4NiYXKCaWSCdjSJc2VjcDI1NmsxoQO98N2ifPfBQV3rqyKvP_drShGWxz2uUqnRJB4cSRwLqA
-    >>> manager.enr[b'foo']
-    b'bar'
-    >>> manager.enr.sequence_number
-    2
+    >>> unsigned_enr = UnsignedENR(
+    ... sequence_number=1,
+    ... kv_pairs={
+    ...     b'id': b'v4',
+    ...     b'secp256k1': private_key.public_key.to_compressed_bytes(),
+    ...     b'unicorns': b'rainbows',
+    ... })
+    >>> enr = unsigned_enr.to_signed_enr(private_key.to_bytes())
+    >>> enr
+    enr:-Ie4QNRDUVEiOYTwwki59qs5SY_ofKSCbFL2BuslZ9fsZXGEMOlfxkFGpojFUj_ArnHMh4bv6E26frE1NII7z4xK9I0BgmlkgnY0iXNlY3AyNTZrMaEDvfDdonz3wUFd66sirz_3a0oRlsc9rlKp0SQeHEkcC6iIdW5pY29ybnOIcmFpbmJvd3M
+    >>> enr == ENR.from_repr("enr:-Ie4QNRDUVEiOYTwwki59qs5SY_ofKSCbFL2BuslZ9fsZXGEMOlfxkFGpojFUj_ArnHMh4bv6E26frE1NII7z4xK9I0BgmlkgnY0iXNlY3AyNTZrMaEDvfDdonz3wUFd66sirz_3a0oRlsc9rlKp0SQeHEkcC6iIdW5pY29ybnOIcmFpbmJvd3M")  # recover an ENR from it's text representation
+    True
 
 
-Manual ENR Creation
+Storing ENR records
 -------------------
 
-You can forgo the :class:`~eth_enr.ENRManager` and create an ENR manually as follows:
-
+You can use the :class:`eth_enr.ENRDB` to store ENR records.  The underlying
+storage is flexible and accepts any dictionary-like object.
 
 .. doctest::
 
     >>> from eth_keys import keys
-    >>> from eth_enr import UnsignedENR
+    >>> from eth_enr import UnsignedENR, ENRDB
     >>> private_key = keys.PrivateKey(b'unicornsrainbowsunicornsrainbows')
     >>> unsigned_enr = UnsignedENR(
     ... sequence_number=1,
@@ -42,5 +45,69 @@ You can forgo the :class:`~eth_enr.ENRManager` and create an ENR manually as fol
     ...     b'secp256k1': private_key.public_key.to_compressed_bytes(),
     ... })
     >>> enr = unsigned_enr.to_signed_enr(private_key.to_bytes())
-    >>> enr
+    >>> enr_db = ENRDB({})
+    >>> enr_db.get_enr(enr.node_id)  # not yet in database
+    Traceback (most recent call last):
+      File "/home/piper/.pyenv/versions/3.6.9/lib/python3.6/doctest.py", line 1330, in __run
+        compileflags, 1), test.globs)
+      File "<doctest default[6]>", line 1, in <module>
+        enr_db.get_enr(enr.node_id)  # not yet in database
+      File "/home/piper/projects/eth-enr/eth_enr/enr_db.py", line 57, in get_enr
+        return rlp.decode(self.db[self._get_enr_key(node_id)], sedes=ENR)  # type: ignore
+    KeyError: b'l?\x85b\xc8\x03\xbf\xae5\xa8\xf5K\x85\x82\xa2\x89V\xb9%\x93M\x03\xdd\xb4Xu\xe1\x8e\x85\x93\x12\xc1:enr'
+    >>> enr_db.set_enr(enr)
+    >>> enr_db.get_enr(enr.node_id)
     enr:-HW4QDBN_uzB2BgXNgpjCN83hSE13oI46ZtFOmWnmYkGTZWrfRF6Yk60HcoiyuLDXqCTcj8fqk2DWetU2ZYJrXUEylIBgmlkgnY0iXNlY3AyNTZrMaEDvfDdonz3wUFd66sirz_3a0oRlsc9rlKp0SQeHEkcC6g
+    >>> updated_enr = UnsignedENR(
+    ... sequence_number=2,
+    ... kv_pairs={
+    ...     b'id': b'v4',
+    ...     b'secp256k1': private_key.public_key.to_compressed_bytes(),
+    ... }).to_signed_enr(private_key.to_bytes())
+    >>> enr_db.set_enr(updated_enr)
+    >>> enr_db.set_enr(enr)  # throws exception due to old sequence number
+    Traceback (most recent call last):
+      File "/home/piper/.pyenv/versions/3.6.9/lib/python3.6/doctest.py", line 1330, in __run
+        compileflags, 1), test.globs)
+      File "<doctest default[11]>", line 1, in <module>
+        enr_db.set_enr(enr)  # throws exception due to old sequence number
+      File "/home/piper/projects/eth-enr/eth_enr/enr_db.py", line 51, in set_enr
+        f"Cannot overwrite existing ENR ({existing_enr.sequence_number}) with old one "
+    eth_enr.exceptions.OldSequenceNumber: Cannot overwrite existing ENR (2) with old one (1)
+    >>> assert enr_db.get_enr(updated_enr.node_id) == updated_enr
+
+
+Using the ENRManager
+--------------------
+
+The :class:`eth_enr.ENRMAnager` automates creation, updating, and storage of ENR records.
+
+.. doctest::
+
+    >>> from eth_keys import keys
+    >>> from eth_enr import ENRManager, ENRDB
+    >>> private_key = keys.PrivateKey(b'unicornsrainbowsunicornsrainbows')
+    >>> manager = ENRManager(private_key, ENRDB({}))
+    >>> manager.enr
+    enr:-HW4QDBN_uzB2BgXNgpjCN83hSE13oI46ZtFOmWnmYkGTZWrfRF6Yk60HcoiyuLDXqCTcj8fqk2DWetU2ZYJrXUEylIBgmlkgnY0iXNlY3AyNTZrMaEDvfDdonz3wUFd66sirz_3a0oRlsc9rlKp0SQeHEkcC6g
+    >>> manager.enr.sequence_number
+    1
+    >>> manager.update((b'foo', b'bar'))
+    >>> manager.enr
+    enr:-H24QNUv1DBIpMITIUjJN8s7foWBJ33rR0liWCu4nVDaXk7ACcXpiMiFJHPC8UKTNkXfN3DXGwPX-Q6KL1uMZwNeyGMCg2Zvb4NiYXKCaWSCdjSJc2VjcDI1NmsxoQO98N2ifPfBQV3rqyKvP_drShGWxz2uUqnRJB4cSRwLqA
+    >>> manager.enr[b'foo']
+    b'bar'
+    >>> manager.enr.sequence_number
+    2
+    >>> manager.update((b'foo', None))  # `None` triggers removal of a key.
+    >>> manager.enr
+    enr:-HW4QFeb9Qg_RNSWamKytj4Eh2eICVKSauQfp4PMY45YQdGzAyFnLjZBU-IuktiGKGiEz2nbEo6w4qNOu_D2Xdmr08gDgmlkgnY0iXNlY3AyNTZrMaEDvfDdonz3wUFd66sirz_3a0oRlsc9rlKp0SQeHEkcC6g
+    >>> manager.enr[b'foo']
+    Traceback (most recent call last):
+      File "/home/piper/.pyenv/versions/3.6.9/lib/python3.6/doctest.py", line 1330, in __run
+        compileflags, 1), test.globs)
+      File "<doctest default[10]>", line 1, in <module>
+        manager.enr[b'foo']
+      File "/home/piper/projects/eth-enr/eth_enr/enr.py", line 93, in __getitem__
+        return self._kv_pairs[key]
+    KeyError: b'foo'

--- a/eth_enr/__init__.py
+++ b/eth_enr/__init__.py
@@ -1,2 +1,18 @@
+from eth_enr.abc import (  # noqa: F401
+    ENRAPI,
+    ENRDatabaseAPI,
+    ENRManagerAPI,
+    IdentitySchemeAPI,
+    IdentitySchemeRegistryAPI,
+    UnsignedENRAPI,
+)
 from eth_enr.enr import ENR, UnsignedENR  # noqa: F401
+from eth_enr.enr_db import ENRDB  # noqa: F401
 from eth_enr.enr_manager import ENRManager  # noqa: F401
+from eth_enr.identity_schemes import (  # noqa: F401
+    IdentitySchemeRegistry,
+    V4CompatIdentityScheme,
+    V4IdentityScheme,
+    default_identity_scheme_registry,
+    discv4_identity_scheme_registry,
+)

--- a/eth_enr/abc.py
+++ b/eth_enr/abc.py
@@ -80,7 +80,12 @@ class ENRManagerAPI(ABC):
         ...
 
     @abstractmethod
-    def update(self, *kv_pairs: ENR_KV) -> ENRAPI:
+    def update(self, *kv_pairs: ENR_KV) -> None:
+        """
+        Update the ENR record with the provided key/value pairs.  Providing
+        `None` for a value will result in the associated key being removed from
+        the ENR.
+        """
         ...
 
 
@@ -119,4 +124,18 @@ class IdentitySchemeAPI(ABC):
     @abstractmethod
     def extract_node_id(cls, enr: CommonENRAPI) -> NodeID:
         """Retrieve the node id from an ENR."""
+        ...
+
+
+class ENRDatabaseAPI(ABC):
+    @abstractmethod
+    def set_enr(self, enr: ENRAPI) -> None:
+        ...
+
+    @abstractmethod
+    def get_enr(self, node_id: NodeID) -> ENRAPI:
+        ...
+
+    @abstractmethod
+    def delete_enr(self, node_id: NodeID) -> None:
         ...

--- a/eth_enr/enr.py
+++ b/eth_enr/enr.py
@@ -14,6 +14,7 @@ from eth_enr.abc import (
     UnsignedENRAPI,
 )
 from eth_enr.constants import ENR_REPR_PREFIX, IDENTITY_SCHEME_ENR_KEY
+from eth_enr.exceptions import UnknownIdentityScheme
 from eth_enr.identity_schemes import (
     default_identity_scheme_registry as default_id_scheme_registry,
 )
@@ -50,7 +51,7 @@ class ENRCommon(CommonENRAPI):
         try:
             return identity_scheme_registry[identity_scheme_id]
         except KeyError:
-            raise ValidationError(
+            raise UnknownIdentityScheme(
                 f"ENR uses unsupported identity scheme {identity_scheme_id}"
             )
 

--- a/eth_enr/enr_db.py
+++ b/eth_enr/enr_db.py
@@ -1,0 +1,63 @@
+import logging
+from typing import MutableMapping, Optional
+
+from eth_typing import NodeID
+import rlp
+
+from eth_enr import ENR
+from eth_enr.abc import ENRAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
+from eth_enr.identity_schemes import default_identity_scheme_registry
+
+
+class ENRDB(ENRDatabaseAPI):
+    logger = logging.getLogger("eth_enr.ENRDB")
+
+    def __init__(
+        self,
+        db: MutableMapping[bytes, bytes],
+        identity_scheme_registry: IdentitySchemeRegistryAPI = default_identity_scheme_registry,
+    ) -> None:
+        self.db = db
+        self._identity_scheme_registry = identity_scheme_registry
+
+    @property
+    def identity_scheme_registry(self) -> IdentitySchemeRegistryAPI:
+        return self._identity_scheme_registry
+
+    def _validate_identity_scheme(self, enr: ENRAPI) -> None:
+        """
+        Check that we know the identity scheme of the ENR.
+
+        This check should be performed whenever an ENR is inserted or updated in serialized form to
+        make sure retrieving it at a later time will succeed (deserializing the ENR would fail if
+        we don't know the identity scheme).
+        """
+        if enr.identity_scheme.id not in self.identity_scheme_registry:
+            raise UnknownIdentityScheme(
+                f"ENRs identity scheme with id {enr.identity_scheme.id!r} unknown to ENR DBs "
+                f"identity scheme registry"
+            )
+
+    def set_enr(self, enr: ENRAPI) -> None:
+        existing_enr: Optional[ENRAPI]
+        self._validate_identity_scheme(enr)
+        try:
+            existing_enr = self.get_enr(enr.node_id)
+        except KeyError:
+            existing_enr = None
+        if existing_enr and existing_enr.sequence_number > enr.sequence_number:
+            raise OldSequenceNumber(
+                f"Cannot overwrite existing ENR ({existing_enr.sequence_number}) with old one "
+                f"({enr.sequence_number})"
+            )
+        self.db[self._get_enr_key(enr.node_id)] = rlp.encode(enr)
+
+    def get_enr(self, node_id: NodeID) -> ENRAPI:
+        return rlp.decode(self.db[self._get_enr_key(node_id)], sedes=ENR)  # type: ignore
+
+    def delete_enr(self, node_id: NodeID) -> None:
+        del self.db[self._get_enr_key(node_id)]
+
+    def _get_enr_key(self, node_id: NodeID) -> bytes:
+        return bytes(node_id) + b":enr"

--- a/eth_enr/enr_manager.py
+++ b/eth_enr/enr_manager.py
@@ -2,16 +2,20 @@ import logging
 from typing import Mapping, Optional
 
 from eth_keys import keys
+from eth_typing import NodeID
+from eth_utils import ValidationError
 from eth_utils.toolz import merge
 
-from eth_enr.abc import ENRAPI, ENRManagerAPI, IdentitySchemeRegistryAPI
+from eth_enr.abc import ENRAPI, ENRDatabaseAPI, ENRManagerAPI, IdentitySchemeRegistryAPI
 from eth_enr.enr import UnsignedENR
 from eth_enr.identity_schemes import default_identity_scheme_registry
 from eth_enr.typing import ENR_KV
 
 
 class ENRManager(ENRManagerAPI):
+    _enr_db: ENRDatabaseAPI
     _enr: ENRAPI
+    _node_id: NodeID
     _identity_scheme_registry: IdentitySchemeRegistryAPI
 
     logger = logging.getLogger("eth_enr.ENRManager")
@@ -19,12 +23,13 @@ class ENRManager(ENRManagerAPI):
     def __init__(
         self,
         private_key: keys.PrivateKey,
-        base_enr: Optional[ENRAPI] = None,
+        enr_db: ENRDatabaseAPI,
         kv_pairs: Optional[Mapping[bytes, bytes]] = None,
         identity_scheme_registry: IdentitySchemeRegistryAPI = default_identity_scheme_registry,  # noqa: E501
     ) -> None:
         self._identity_scheme_registry = identity_scheme_registry
         self._private_key = private_key
+        self._enr_db = enr_db
 
         if kv_pairs is None:
             kv_pairs = {}
@@ -42,32 +47,57 @@ class ENRManager(ENRManagerAPI):
             kv_pairs=merge(identity_kv_pairs, kv_pairs),
             identity_scheme_registry=self._identity_scheme_registry,
         ).to_signed_enr(self._private_key.to_bytes())
+        self._node_id = minimal_enr.node_id
 
-        if base_enr is None:
+        try:
+            base_enr = self._enr_db.get_enr(minimal_enr.node_id)
+        except KeyError:
             self.logger.info(
-                "Local ENR created: seq=%d  enr=%r",
+                "ENR created: seq=%d  enr=%r",
                 minimal_enr.sequence_number,
                 minimal_enr,
             )
             self._enr = minimal_enr
+            self._enr_db.set_enr(self._enr)
         else:
             self._enr = base_enr
-            self.update(*tuple(dict(minimal_enr).items()))
+            self.update(*tuple(kv_pairs.items()))
 
     @property
     def enr(self) -> ENRAPI:
         return self._enr
 
-    def update(self, *kv_pairs: ENR_KV) -> ENRAPI:
-        if any(
-            key not in self._enr or self._enr[key] != value for key, value in kv_pairs
-        ):
+    def update(self, *kv_pairs: ENR_KV) -> None:
+        if not kv_pairs:
+            return
+        keys, values = tuple(zip(*kv_pairs))
+        if len(keys) != len(set(keys)):
+            raise ValidationError("Duplicate keys found in: %s", keys)
+
+        needs_update = any(
+            (
+                # key needs to be deleted
+                (value is None and key in self._enr)
+                # key is not present or does not match the provided value
+                or (
+                    value is not None
+                    and (key not in self._enr or self._enr[key] != value)
+                )
+            )
+            for key, value in kv_pairs
+        )
+        if needs_update:
+            merged_kv_pairs = {
+                key: value
+                for key, value in merge(dict(self._enr), dict(kv_pairs)).items()
+                if value is not None
+            }
             self._enr = UnsignedENR(
                 sequence_number=self._enr.sequence_number + 1,
-                kv_pairs=merge(dict(self._enr), dict(kv_pairs)),
+                kv_pairs=merged_kv_pairs,
                 identity_scheme_registry=self._identity_scheme_registry,
             ).to_signed_enr(self._private_key.to_bytes())
+            self._enr_db.set_enr(self._enr)
             self.logger.info(
-                "Local ENR Updated: seq=%d  enr=%r", self.enr.sequence_number, self.enr
+                "ENR Updated: seq=%d  enr=%r", self.enr.sequence_number, self.enr
             )
-        return self._enr

--- a/eth_enr/exceptions.py
+++ b/eth_enr/exceptions.py
@@ -1,0 +1,23 @@
+class BaseENRException(Exception):
+    """
+    Common base class for all library exceptions
+    """
+
+    pass
+
+
+class UnknownIdentityScheme(BaseENRException):
+    """
+    Raised when trying to instantiate an ENR with an unknown identity scheme
+    """
+
+    pass
+
+
+class OldSequenceNumber(BaseENRException):
+    """
+    Raised when trying to update an ENR record with a sequence number that is
+    older than the latest sequence number we have seen
+    """
+
+    pass

--- a/eth_enr/typing.py
+++ b/eth_enr/typing.py
@@ -1,3 +1,3 @@
 from typing import Tuple, Union
 
-ENR_KV = Tuple[bytes, Union[int, bytes]]
+ENR_KV = Tuple[bytes, Union[int, bytes, None]]

--- a/tests/core/test_enr.py
+++ b/tests/core/test_enr.py
@@ -7,6 +7,7 @@ import rlp
 
 from eth_enr.abc import IdentitySchemeAPI
 from eth_enr.enr import ENR, UnsignedENR
+from eth_enr.exceptions import UnknownIdentityScheme
 from eth_enr.identity_schemes import IdentitySchemeRegistry, V4IdentityScheme
 from eth_enr.sedes import ENRSedes
 
@@ -211,7 +212,7 @@ def test_signature_validation(mock_identity_scheme, identity_scheme_registry):
     with pytest.raises(ValidationError):
         invalid_enr.validate_signature()
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(UnknownIdentityScheme):
         ENR(
             0,
             {b"id": b"unknown"},
@@ -243,7 +244,7 @@ def test_signature_scheme_selection(mock_identity_scheme, identity_scheme_regist
     )
     assert v4_enr.identity_scheme is V4IdentityScheme
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(UnknownIdentityScheme):
         ENR(0, {b"id": b"other"}, b"", identity_scheme_registry)
 
 

--- a/tests/core/test_enr_db.py
+++ b/tests/core/test_enr_db.py
@@ -1,0 +1,54 @@
+import pytest
+
+from eth_enr.enr_db import ENRDB
+from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
+from eth_enr.identity_schemes import IdentitySchemeRegistry
+from eth_enr.tools.factories import ENRFactory, PrivateKeyFactory
+
+
+@pytest.fixture
+def enr_db():
+    return ENRDB({})
+
+
+def test_checks_identity_scheme():
+    db = ENRDB(IdentitySchemeRegistry(), {})
+    enr = ENRFactory()
+
+    with pytest.raises(UnknownIdentityScheme):
+        db.set_enr(enr)
+
+
+def test_get_and_set_enr(enr_db):
+    private_key = PrivateKeyFactory().to_bytes()
+    db = enr_db
+    enr = ENRFactory(private_key=private_key)
+
+    with pytest.raises(KeyError):
+        db.get_enr(enr.node_id)
+
+    db.set_enr(enr)
+    assert db.get_enr(enr.node_id) == enr
+
+    updated_enr = ENRFactory(
+        private_key=private_key, sequence_number=enr.sequence_number + 1
+    )
+    db.set_enr(updated_enr)
+    assert db.get_enr(enr.node_id) == updated_enr
+
+    with pytest.raises(OldSequenceNumber):
+        db.set_enr(enr)
+
+
+def test_delete_enr(enr_db):
+    db = enr_db
+    enr = ENRFactory()
+
+    with pytest.raises(KeyError):
+        db.delete_enr(enr.node_id)
+
+    db.set_enr(enr)
+    db.delete_enr(enr.node_id)
+
+    with pytest.raises(KeyError):
+        db.get_enr(enr.node_id)

--- a/tests/core/test_enr_manager.py
+++ b/tests/core/test_enr_manager.py
@@ -1,21 +1,32 @@
+from eth_utils import ValidationError
+import pytest
+
+from eth_enr.enr_db import ENRDB
 from eth_enr.enr_manager import ENRManager
 from eth_enr.tools.factories import ENRFactory, PrivateKeyFactory
 
 
-def test_enr_manager_creates_enr_if_not_present():
-    enr_manager = ENRManager(PrivateKeyFactory())
+@pytest.fixture
+def enr_db():
+    return ENRDB({})
+
+
+def test_enr_manager_creates_enr_if_not_present(enr_db):
+    enr_manager = ENRManager(PrivateKeyFactory(), enr_db)
     assert enr_manager.enr
+    assert enr_db.get_enr(enr_manager.enr.node_id) == enr_manager.enr
 
 
-def test_enr_manager_handles_existing_enr():
+def test_enr_manager_handles_existing_enr_in_database(enr_db):
     private_key = PrivateKeyFactory()
-    base_enr = ENRFactory(private_key=private_key.to_bytes(), sequence_number=0)
+    enr = ENRFactory(private_key=private_key.to_bytes(), sequence_number=10)
+    enr_db.set_enr(enr)
 
-    enr_manager = ENRManager(private_key, base_enr=base_enr)
-    assert enr_manager.enr == base_enr
+    enr_manager = ENRManager(private_key, enr_db)
+    assert enr_manager.enr == enr
 
 
-def test_enr_manager_updates_existing_enr():
+def test_enr_manager_updates_existing_enr(enr_db):
     private_key = PrivateKeyFactory()
     base_enr = ENRFactory(
         private_key=private_key.to_bytes(),
@@ -23,28 +34,44 @@ def test_enr_manager_updates_existing_enr():
         custom_kv_pairs={b"unicorns": b"rainbows"},
     )
     assert base_enr[b"unicorns"] == b"rainbows"
+    enr_db.set_enr(base_enr)
 
     enr_manager = ENRManager(
         private_key,
+        enr_db,
         kv_pairs={b"unicorns": b"cupcakes"},
-        base_enr=base_enr,
     )
     assert enr_manager.enr != base_enr
     assert enr_manager.enr.sequence_number == base_enr.sequence_number + 1
     assert enr_manager.enr[b"unicorns"] == b"cupcakes"
+    assert enr_manager.enr == enr_db.get_enr(enr_manager.enr.node_id)
 
 
-def test_enr_manager_update_api():
-    enr_manager = ENRManager(PrivateKeyFactory())
+def test_enr_manager_update_api(enr_db):
+    enr_manager = ENRManager(PrivateKeyFactory(), enr_db)
     assert b"unicorns" not in enr_manager.enr
     base_enr = enr_manager.enr
 
-    enr_a = enr_manager.update((b"unicorns", b"rainbows"))
+    enr_manager.update((b"unicorns", b"rainbows"))
+    enr_a = enr_manager.enr
     assert enr_a.sequence_number == base_enr.sequence_number + 1
+    assert enr_manager.enr == enr_db.get_enr(enr_manager.enr.node_id)
 
     assert enr_manager.enr[b"unicorns"] == b"rainbows"
 
-    enr_b = enr_manager.update((b"unicorns", b"cupcakes"))
+    enr_manager.update((b"unicorns", b"cupcakes"))
+    enr_b = enr_manager.enr
     assert enr_b.sequence_number == enr_a.sequence_number + 1
+    assert enr_manager.enr == enr_db.get_enr(enr_manager.enr.node_id)
 
     assert enr_manager.enr[b"unicorns"] == b"cupcakes"
+
+    with pytest.raises(ValidationError):
+        enr_manager.update((b"dup", b"a"), (b"dup", b"b"))
+
+    enr_manager.update((b"unicorns", None))
+    enr_c = enr_manager.enr
+    assert enr_manager.enr == enr_db.get_enr(enr_manager.enr.node_id)
+
+    with pytest.raises(KeyError):
+        enr_c[b"unicorns"]


### PR DESCRIPTION
## What was wrong?

It turns out that having a standard storage engine is beneficial, especially for the `ENRManager` which is supposed to automate the majority of managing an ENR record.

## How was it fixed?

Added `ENRDatabaseAPI` and implementations.

#### Cute Animal Picture

![Animal-Kingdom-Rhino](https://user-images.githubusercontent.com/824194/92148042-33be0a00-edd9-11ea-9b48-76b786fef3ee.jpg)

