### PR TITLE
Piper/query by attribute

### DIFF
--- a/eth_enr/abc.py
+++ b/eth_enr/abc.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import UserDict
-from typing import TYPE_CHECKING, Any, Mapping, Type
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Type
 
 from eth_typing import NodeID
 
@@ -138,4 +138,14 @@ class ENRDatabaseAPI(ABC):
 
     @abstractmethod
     def delete_enr(self, node_id: NodeID) -> None:
+        ...
+
+
+class ConstraintAPI(ABC):
+    ...
+
+
+class QueryableENRDatabaseAPI(ENRDatabaseAPI):
+    @abstractmethod
+    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
         ...

--- a/eth_enr/constraints.py
+++ b/eth_enr/constraints.py
@@ -1,0 +1,30 @@
+from eth_enr.abc import ConstraintAPI
+
+
+class KeyExists(ConstraintAPI):
+    key: bytes
+
+    def __init__(self, key: bytes) -> None:
+        self.key = key
+
+
+class HasUDPIPv4Endpoint(ConstraintAPI):
+    pass
+
+
+class HasTCPIPv4Endpoint(ConstraintAPI):
+    pass
+
+
+class HasUDPIPv6Endpoint(ConstraintAPI):
+    pass
+
+
+class HasTCPIPv6Endpoint(ConstraintAPI):
+    pass
+
+
+has_tcp_ipv4_endpoint = HasTCPIPv4Endpoint()
+has_tcp_ipv6_endpoint = HasTCPIPv6Endpoint()
+has_udp_ipv4_endpoint = HasUDPIPv4Endpoint()
+has_udp_ipv6_endpoint = HasUDPIPv6Endpoint()

--- a/eth_enr/db_models.py
+++ b/eth_enr/db_models.py
@@ -1,0 +1,149 @@
+import datetime
+from typing import Tuple, Union
+
+import rlp
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    UniqueConstraint,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, scoped_session, sessionmaker
+
+from eth_enr.abc import ENRAPI
+from eth_enr.enr import ENR
+from eth_enr.sedes import ENR_KEY_SEDES_MAPPING
+
+Base = declarative_base()
+
+Session = scoped_session(sessionmaker())
+
+
+def _encode_enr_value(key: bytes, value: Union[int, bytes]) -> bytes:
+    try:
+        sedes = ENR_KEY_SEDES_MAPPING[key]
+    except KeyError:
+        if isinstance(value, bytes):
+            return value
+        else:
+            raise TypeError("Cannot store non-bytes value: {type(value)}")
+    else:
+        return rlp.encode(value, sedes=sedes)  # type: ignore
+
+
+def _decode_enr_value(key: bytes, raw: bytes) -> Union[int, bytes]:
+    try:
+        sedes = ENR_KEY_SEDES_MAPPING[key]
+    except KeyError:
+        return raw
+    else:
+        return rlp.decode(raw, sedes=sedes)  # type: ignore
+
+
+class Record(Base):
+    query = Session.query_property()
+
+    __tablename__ = "record"
+    __table_args__ = (
+        Index(
+            "ix_node_id_sequence_number",
+            "node_id",
+            "sequence_number",
+            unique=True,
+        ),
+        CheckConstraint("sequence_number >= 0", name="_sequence_number_positive"),
+    )
+
+    node_id = Column(LargeBinary(32), primary_key=True)
+    sequence_number = Column(Integer, primary_key=True)
+
+    signature = Column(LargeBinary(), nullable=False)
+
+    created_at = Column(DateTime(), nullable=False)
+
+    fields = relationship(
+        "Field",
+        back_populates="record",
+        foreign_keys="(Field.node_id, Field.sequence_number)",
+        primaryjoin=(
+            "and_("
+            "Record.node_id == Field.node_id, "
+            "Record.sequence_number == Field.sequence_number"
+            ")"
+        ),
+    )
+
+    @classmethod
+    def from_enr(cls, enr: ENRAPI) -> Tuple["Record", Tuple["Field", ...]]:
+        record = cls(
+            node_id=enr.node_id,
+            sequence_number=enr.sequence_number,
+            signature=enr.signature,
+            created_at=datetime.datetime.utcnow(),
+        )
+        fields = tuple(
+            Field(  # type: ignore
+                node_id=enr.node_id,
+                sequence_number=enr.sequence_number,
+                key=key,
+                value=_encode_enr_value(key, value),
+            )
+            for key, value in enr.items()
+        )
+        return record, fields
+
+    def to_enr(self) -> ENRAPI:
+        kv_pairs = {
+            field.key: _decode_enr_value(field.key, field.value)
+            for field in self.fields  # type: ignore
+        }
+        return ENR(
+            sequence_number=self.sequence_number,
+            kv_pairs=kv_pairs,
+            signature=self.signature,
+        )
+
+
+class Field(Base):
+    query = Session.query_property()
+
+    __tablename__ = "field"
+    __table_args__ = (
+        Index(
+            "ix_node_id_sequence_number_key",
+            "node_id",
+            "sequence_number",
+            "key",
+            unique=True,
+        ),
+        UniqueConstraint(
+            "node_id",
+            "sequence_number",
+            "key",
+            name="uix_node_id_key",
+        ),
+    )
+
+    node_id = Column(LargeBinary(32), ForeignKey("record.node_id"), primary_key=True)
+    sequence_number = Column(
+        Integer, ForeignKey("record.sequence_number"), primary_key=True
+    )
+    key = Column(LargeBinary(), primary_key=True)
+    value = Column(LargeBinary(), nullable=False)
+
+    record = relationship(
+        "Record",
+        back_populates="fields",
+        foreign_keys=(node_id, sequence_number),
+        primaryjoin=(
+            "and_("
+            "Record.node_id == Field.node_id, "
+            "Record.sequence_number == Field.sequence_number"
+            ")"
+        ),
+    )

--- a/eth_enr/enr_db.py
+++ b/eth_enr/enr_db.py
@@ -1,11 +1,11 @@
 import logging
-from typing import MutableMapping, Optional
+from typing import Iterable, MutableMapping, Optional
 
 from eth_typing import NodeID
 import rlp
 
 from eth_enr import ENR
-from eth_enr.abc import ENRAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.abc import ENRAPI, ConstraintAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
 from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
 from eth_enr.identity_schemes import default_identity_scheme_registry
 
@@ -61,3 +61,6 @@ class ENRDB(ENRDatabaseAPI):
 
     def _get_enr_key(self, node_id: NodeID) -> bytes:
         return bytes(node_id) + b":enr"
+
+    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
+        raise NotImplementedError

--- a/eth_enr/query_db.py
+++ b/eth_enr/query_db.py
@@ -1,0 +1,122 @@
+import logging
+from typing import Iterable
+
+from eth_typing import NodeID
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.expression import ClauseElement, desc
+
+from eth_enr.abc import ENRAPI, ConstraintAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.constraints import (
+    HasTCPIPv4Endpoint,
+    HasTCPIPv6Endpoint,
+    HasUDPIPv4Endpoint,
+    HasUDPIPv6Endpoint,
+    KeyExists,
+)
+from eth_enr.db_models import Field, Record, Session
+from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
+from eth_enr.identity_schemes import default_identity_scheme_registry
+
+
+def _get_filters(*constraints: ConstraintAPI) -> Iterable[ClauseElement]:
+    for constraint in constraints:
+        if isinstance(constraint, KeyExists):
+            yield Record.fields.any(Field.key == constraint.key)
+        elif isinstance(constraint, HasTCPIPv4Endpoint):
+            yield Record.fields.any(Field.key == b"ip")
+            yield Record.fields.any(Field.key == b"tcp")
+        elif isinstance(constraint, HasTCPIPv6Endpoint):
+            yield Record.fields.any(Field.key == b"ip6")
+            yield Record.fields.any(Field.key == b"tcp6")
+        elif isinstance(constraint, HasUDPIPv4Endpoint):
+            yield Record.fields.any(Field.key == b"ip")
+            yield Record.fields.any(Field.key == b"udp")
+        elif isinstance(constraint, HasUDPIPv6Endpoint):
+            yield Record.fields.any(Field.key == b"ip6")
+            yield Record.fields.any(Field.key == b"udp6")
+        else:
+            raise TypeError(f"Unsupported constraint type: {type(constraint)}")
+
+
+class QueryableENRDB(ENRDatabaseAPI):
+    logger = logging.getLogger("eth_enr.ENRDB")
+
+    def __init__(
+        self,
+        session: Session,  # type: ignore
+        identity_scheme_registry: IdentitySchemeRegistryAPI = default_identity_scheme_registry,
+    ) -> None:
+        self.session = session
+        self._identity_scheme_registry = identity_scheme_registry
+
+    @property
+    def identity_scheme_registry(self) -> IdentitySchemeRegistryAPI:
+        return self._identity_scheme_registry
+
+    def _validate_identity_scheme(self, enr: ENRAPI) -> None:
+        """
+        Check that we know the identity scheme of the ENR.
+
+        This check should be performed whenever an ENR is inserted or updated in serialized form to
+        make sure retrieving it at a later time will succeed (deserializing the ENR would fail if
+        we don't know the identity scheme).
+        """
+        if enr.identity_scheme.id not in self.identity_scheme_registry:
+            raise UnknownIdentityScheme(
+                f"ENRs identity scheme with id {enr.identity_scheme.id!r} unknown to ENR DBs "
+                f"identity scheme registry"
+            )
+
+    def set_enr(self, enr: ENRAPI) -> None:
+        record, fields = Record.from_enr(enr)
+
+        try:
+            with self.session.begin_nested():  # type: ignore
+                self.session.add(record)  # type: ignore
+                self.session.add_all(fields)  # type: ignore
+        except IntegrityError:
+            raise OldSequenceNumber
+
+    def get_enr(self, node_id: NodeID) -> ENRAPI:
+        record: Record = (
+            self.session.query(Record)  # type: ignore
+            .filter(
+                Record.node_id == node_id,
+            )
+            .order_by(desc("sequence_number"))
+            .first()
+        )
+        if record is None:
+            raise KeyError(node_id)
+
+        return record.to_enr()
+
+    def delete_enr(self, node_id: NodeID) -> None:
+        with self.session.begin_nested():  # type: ignore
+            deleted_rows = sum(
+                (
+                    self.session.query(Field).filter(Field.node_id == node_id).delete(),  # type: ignore  # noqa: E501
+                    self.session.query(Record)  # type: ignore
+                    .filter(Record.node_id == node_id)
+                    .delete(),
+                )
+            )
+        if not deleted_rows:
+            raise KeyError(node_id)
+
+    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
+        filters = _get_filters(*constraints)
+        records: Iterable[Record] = (
+            self.session.query(Record)  # type: ignore
+            .join(Record.fields)
+            .group_by(
+                Record.node_id,
+            )
+            .having(
+                func.max(Record.sequence_number),
+            )
+            .filter(*filters)
+            .all()
+        )
+        return (record.to_enr() for record in records)

--- a/eth_enr/tools/factories.py
+++ b/eth_enr/tools/factories.py
@@ -8,7 +8,9 @@ from eth_keys import keys
 from eth_utils import int_to_big_endian
 from eth_utils.toolz import merge
 import factory
+from faker import Faker
 
+from eth_enr.abc import ENRAPI
 from eth_enr.enr import ENR, UnsignedENR
 from eth_enr.identity_schemes import V4IdentityScheme
 
@@ -107,3 +109,19 @@ class ENRFactory(factory.Factory):  # type: ignore
         private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
         address = factory.SubFactory(AddressFactory)
         custom_kv_pairs: Dict[bytes, Any] = {}
+
+    @classmethod
+    def minimal(cls) -> ENRAPI:
+        private_key = PrivateKeyFactory()
+        kv_pairs = {
+            b"id": b"v4",
+            b"secp256k1": private_key.public_key.to_compressed_bytes(),
+        }
+        return cls(private_key=private_key.to_bytes(), kv_pairs=kv_pairs)
+
+
+_faker = Faker()
+
+
+def IPv6Factory() -> ipaddress.IPv6Address:
+    return ipaddress.IPv6Address(_faker.ipv6())

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+plugins = sqlmypy
 
 check_untyped_defs = True
 disallow_incomplete_defs = True

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extras_require = {
         "mypy==0.782",
         "pydocstyle>=3.0.0,<4",
         "black==20.8b1",
+        "sqlalchemy-stubs==0.3",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",
@@ -31,13 +32,17 @@ extras_require = {
         "twine",
         "ipython",
     ],
+    'orm': [
+        "SQLAlchemy>=1.3.19,<1.4",
+    ]
 }
 
 extras_require['dev'] = (
     extras_require['dev'] +  # noqa: W504
     extras_require['test'] +  # noqa: W504
     extras_require['lint'] +  # noqa: W504
-    extras_require['doc']
+    extras_require['doc'] +  # noqa: W504
+    extras_require['orm']
 )
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy import create_engine
+
+from eth_enr.db_models import Base, Session
+
+
+@pytest.fixture(scope="session")
+def engine():
+    # PRO-TIP: Set `echo=True` for lots more SQL debug log output.
+    return create_engine("sqlite:///:memory:", echo=False)
+
+
+@pytest.fixture(scope="session")
+def _schema(engine):
+    Base.metadata.create_all(engine)
+
+
+@pytest.fixture(scope="session")
+def _Session(engine, _schema):
+    Session.configure(bind=engine)
+    return Session
+
+
+@pytest.fixture
+def session(_Session, _schema):
+    session = Session()
+    transaction = session.begin_nested()
+    session.commit = lambda: None
+
+    try:
+        yield session
+    finally:
+        transaction.rollback()
+        session.close()

--- a/tests/core/test_enr_db.py
+++ b/tests/core/test_enr_db.py
@@ -3,12 +3,19 @@ import pytest
 from eth_enr.enr_db import ENRDB
 from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
 from eth_enr.identity_schemes import IdentitySchemeRegistry
+from eth_enr.query_db import QueryableENRDB
 from eth_enr.tools.factories import ENRFactory, PrivateKeyFactory
 
 
-@pytest.fixture
-def enr_db():
-    return ENRDB({})
+@pytest.fixture(params=("mapping", "orm"))
+def enr_db(request):
+    if request.param == "mapping":
+        return ENRDB({})
+    elif request.param == "orm":
+        session = request.getfixturevalue("session")
+        return QueryableENRDB(session)
+    else:
+        raise Exception(f"Unsupported param: {request.param}")
 
 
 def test_checks_identity_scheme():

--- a/tests/core/test_enr_db_query.py
+++ b/tests/core/test_enr_db_query.py
@@ -1,0 +1,137 @@
+import pytest
+
+from eth_enr.constraints import (
+    KeyExists,
+    has_tcp_ipv4_endpoint,
+    has_tcp_ipv6_endpoint,
+    has_udp_ipv4_endpoint,
+    has_udp_ipv6_endpoint,
+)
+from eth_enr.query_db import QueryableENRDB
+from eth_enr.tools.factories import ENRFactory, IPv6Factory, PrivateKeyFactory
+
+
+@pytest.fixture
+def enr_db(session):
+    return QueryableENRDB(session)
+
+
+def test_query_with_empty_database(enr_db):
+    assert not tuple(enr_db.query(KeyExists(b"nope")))
+    assert not tuple(enr_db.query())
+
+
+def test_query_by_key_existence(enr_db):
+    enr_a = ENRFactory(custom_kv_pairs={b"test": b"value-A"})
+    enr_b = ENRFactory(custom_kv_pairs={b"test": b"value-B"})
+    enr_c = ENRFactory()
+
+    enr_db.set_enr(enr_a)
+    enr_db.set_enr(enr_b)
+    enr_db.set_enr(enr_c)
+
+    enr_results = set(enr_db.query(KeyExists(b"test")))
+    assert len(enr_results) == 2
+
+    assert enr_a in enr_results
+    assert enr_b in enr_results
+    assert enr_c not in enr_results
+
+
+def test_query_only_returns_latest_record(enr_db):
+    private_key_a = PrivateKeyFactory().to_bytes()
+
+    enr_a_0 = ENRFactory(sequence_number=0, private_key=private_key_a)
+    enr_a_7 = ENRFactory(sequence_number=7, private_key=private_key_a)
+
+    private_key_b = PrivateKeyFactory().to_bytes()
+
+    enr_b_1 = ENRFactory(sequence_number=1, private_key=private_key_b)
+    enr_b_9 = ENRFactory(sequence_number=9, private_key=private_key_b)
+
+    enr_db.set_enr(enr_a_0)
+    enr_db.set_enr(enr_a_7)
+
+    enr_db.set_enr(enr_b_1)
+    enr_db.set_enr(enr_b_9)
+
+    enr_results = set(enr_db.query())
+    assert len(enr_results) == 2
+
+    assert enr_a_7 in enr_results
+    assert enr_b_9 in enr_results
+
+
+def test_query_excludes_outdated_matching_records(enr_db):
+    private_key_a = PrivateKeyFactory().to_bytes()
+
+    enr_a_0 = ENRFactory(
+        sequence_number=0,
+        private_key=private_key_a,
+        custom_kv_pairs={b"test": b"value-A"},
+    )
+    enr_a_7 = ENRFactory(sequence_number=7, private_key=private_key_a)
+
+    private_key_b = PrivateKeyFactory().to_bytes()
+
+    enr_b_1 = ENRFactory(
+        sequence_number=1,
+        private_key=private_key_b,
+        custom_kv_pairs={b"test": b"value-A"},
+    )
+
+    enr_db.set_enr(enr_a_0)
+    enr_db.set_enr(enr_a_7)
+
+    enr_db.set_enr(enr_b_1)
+
+    enr_results = tuple(enr_db.query(KeyExists(b"test")))
+    assert len(enr_results) == 1
+
+    enr = enr_results[0]
+    assert enr == enr_b_1
+
+
+@pytest.mark.parametrize("constraint", (has_tcp_ipv4_endpoint, has_udp_ipv4_endpoint))
+def test_query_for_ipv4_endpoint(enr_db, constraint):
+    enr_a = ENRFactory.minimal()
+    enr_b = ENRFactory()
+    enr_c = ENRFactory.minimal()
+
+    enr_db.set_enr(enr_a)
+    enr_db.set_enr(enr_b)
+    enr_db.set_enr(enr_c)
+
+    enr_results = tuple(enr_db.query(constraint))
+    assert len(enr_results) == 1
+
+    enr = enr_results[0]
+
+    assert enr == enr_b
+
+
+@pytest.mark.parametrize("constraint", (has_tcp_ipv6_endpoint, has_udp_ipv6_endpoint))
+def test_query_for_ipv6_endpoint(enr_db, constraint):
+    ip6 = IPv6Factory()
+    stub = ENRFactory()
+
+    enr_a = ENRFactory.minimal()
+    enr_b = ENRFactory(
+        custom_kv_pairs={
+            b"ip6": ip6.packed,
+            b"tcp6": stub[b"tcp"],
+            b"udp6": stub[b"udp"],
+        }
+    )
+    enr_c = ENRFactory.minimal()
+
+    enr_db.set_enr(enr_a)
+    enr_db.set_enr(enr_b)
+    enr_db.set_enr(enr_c)
+
+    enr_results = tuple(enr_db.query(constraint))
+    assert len(enr_results) == 1
+
+    enr = enr_results[0]
+
+    assert enr == enr_b

--- a/tests/core/test_orm_models.py
+++ b/tests/core/test_orm_models.py
@@ -1,0 +1,22 @@
+from eth_enr.db_models import Record
+from eth_enr.tools.factories import ENRFactory
+
+
+def test_orm_enr_saving_and_loading(session):
+    enr = ENRFactory()
+    record, fields = Record.from_enr(enr)
+
+    with session.begin_nested():
+        session.add(record)
+        session.add_all(fields)
+
+    record_from_db = (
+        Record.query.filter(
+            Record.node_id == enr.node_id,
+        )
+        .filter(Record.sequence_number == enr.sequence_number)
+        .one()
+    )
+    enr_from_db = record_from_db.to_enr()
+
+    assert enr_from_db == enr

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ basepython =
     py38: python3.8
 extras=
     test
+    orm
     docs: doc
 whitelist_externals=make
 


### PR DESCRIPTION
## What was wrong?

Being able to query and enumerate the ENR database is becoming a necessary API.

1. Need to filter ENR records down to only those that have ip/port information
2. Search for ENR records that have a specific key.

## How was it fixed?

This implements a new `QueryableENRDatabaseAPI` which exposes one extra `query(...)` method.

TODO: explain more

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
