### PR TITLE
Implement queryable ENR database

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,6 +40,18 @@ Abstract Base Classes
     :show-inheritance:
 
 
+.. autoclass:: eth_enr.abc.ENRDatabaseAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.abc.QueryableENRDatabaseAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Classes
 -------
 
@@ -50,12 +62,6 @@ Classes
 
 
 .. autoclass:: eth_enr.enr.UnsignedENR
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-.. autoclass:: eth_enr.enr_db.ENRDB
     :members:
     :undoc-members:
     :show-inheritance:
@@ -80,6 +86,68 @@ Classes
 
 
 .. autoclass:: eth_enr.identity_schemes.V4CompatIdentityScheme
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.enr_db.ENRDB
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.query_db.QueryableENRDB
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Constraints
+-----------
+
+
+.. autoclass:: eth_enr.constraints.KeyExists
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.constraints.HasUDPIPv4Endpoint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.constraints.HasUDPIPv6Endpoint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.constraints.HasTCPIPv4Endpoint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.constraints.HasTCPIPv6Endpoint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Exceptions
+----------
+
+
+.. autoclass:: eth_enr.exceptions.OldSequenceNumber
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: eth_enr.exceptions.UnknownIdentityScheme
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -130,9 +130,9 @@ using the ``sqlite3`` standard library.
     >>> from eth_keys import keys
     >>> from eth_enr import UnsignedENR, QueryableENRDB
     >>> from eth_enr.constraints import KeyExists
-    >>> private_key_a = keys.PrivateKey(b'unicornsrainbowsunicornsrainbows')
-    >>> private_key_b = keys.PrivateKey(b'rainbowsunicornsrainbowsunicorns')
-    >>> private_key_c = keys.PrivateKey(b'rainbowsunicornsrainbowsunicorns')
+    >>> private_key_a = keys.PrivateKey(b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+    >>> private_key_b = keys.PrivateKey(b'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')
+    >>> private_key_c = keys.PrivateKey(b'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC')
     >>> enr_a = UnsignedENR(
     ... sequence_number=1,
     ... kv_pairs={

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -111,3 +111,58 @@ The :class:`eth_enr.ENRMAnager` automates creation, updating, and storage of ENR
       File "/home/piper/projects/eth-enr/eth_enr/enr.py", line 93, in __getitem__
         return self._kv_pairs[key]
     KeyError: b'foo'
+
+
+Querying ENR Records
+--------------------
+
+You can use the :class:`eth_enr.QueryableENRDB` which exposes the same API as
+:class:`eth_enr.ENRDB` with one additional :meth:`eth_enr.QueryableENRDB.query`
+method.
+
+The :class:`eth_enr.QueryableENRDB` operates on top of any SQLite3 database
+using the ``sqlite3`` standard library.
+
+
+.. doctest::
+
+    >>> import sqlite3
+    >>> from eth_keys import keys
+    >>> from eth_enr import UnsignedENR, QueryableENRDB
+    >>> from eth_enr.constraints import KeyExists
+    >>> private_key_a = keys.PrivateKey(b'unicornsrainbowsunicornsrainbows')
+    >>> private_key_b = keys.PrivateKey(b'rainbowsunicornsrainbowsunicorns')
+    >>> private_key_c = keys.PrivateKey(b'rainbowsunicornsrainbowsunicorns')
+    >>> enr_a = UnsignedENR(
+    ... sequence_number=1,
+    ... kv_pairs={
+    ...     b'id': b'v4',
+    ...     b'secp256k1': private_key_a.public_key.to_compressed_bytes(),
+    ...     b'unicorns': b'rainbows',
+    ... }).to_signed_enr(private_key_a.to_bytes())
+    >>> enr_b = UnsignedENR(
+    ... sequence_number=7,
+    ... kv_pairs={
+    ...     b'id': b'v4',
+    ...     b'secp256k1': private_key_b.public_key.to_compressed_bytes(),
+    ...     b'unicorns': b'rainbows',
+    ...     b'cupcakes': b'sparkles',
+    ... }).to_signed_enr(private_key_b.to_bytes())
+    >>> enr_c = UnsignedENR(
+    ... sequence_number=2,
+    ... kv_pairs={
+    ...     b'id': b'v4',
+    ...     b'secp256k1': private_key_c.public_key.to_compressed_bytes(),
+    ... }).to_signed_enr(private_key_c.to_bytes())
+    >>> connection = sqlite3.connect(":memory:")
+    >>> enr_db = QueryableENRDB(connection)
+    >>> enr_db.set_enr(enr_a)
+    >>> enr_db.set_enr(enr_b)
+    >>> enrs_with_unicorns = tuple(enr_db.query(KeyExists(b'unicorns')))
+    >>> assert enr_a in enrs_with_unicorns
+    >>> assert enr_b in enrs_with_unicorns
+    >>> assert enr_c not in enrs_with_unicorns
+    >>> enrs_with_cupcakes = tuple(enr_db.query(KeyExists(b'cupcakes')))
+    >>> assert enr_a not in enrs_with_cupcakes
+    >>> assert enr_b in enrs_with_cupcakes
+    >>> assert enr_c not in enrs_with_cupcakes

--- a/eth_enr/__init__.py
+++ b/eth_enr/__init__.py
@@ -9,6 +9,7 @@ from eth_enr.abc import (  # noqa: F401
 from eth_enr.enr import ENR, UnsignedENR  # noqa: F401
 from eth_enr.enr_db import ENRDB  # noqa: F401
 from eth_enr.enr_manager import ENRManager  # noqa: F401
+from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme  # noqa: F401
 from eth_enr.identity_schemes import (  # noqa: F401
     IdentitySchemeRegistry,
     V4CompatIdentityScheme,

--- a/eth_enr/__init__.py
+++ b/eth_enr/__init__.py
@@ -16,3 +16,4 @@ from eth_enr.identity_schemes import (  # noqa: F401
     default_identity_scheme_registry,
     discv4_identity_scheme_registry,
 )
+from eth_enr.query_db import QueryableENRDB  # noqa: F401

--- a/eth_enr/abc.py
+++ b/eth_enr/abc.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import UserDict
-from typing import TYPE_CHECKING, Any, Mapping, Type
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Type
 
 from eth_typing import NodeID
 
@@ -138,4 +138,14 @@ class ENRDatabaseAPI(ABC):
 
     @abstractmethod
     def delete_enr(self, node_id: NodeID) -> None:
+        ...
+
+
+class ConstraintAPI(ABC):
+    ...
+
+
+class QueryableENRDatabaseAPI(ENRDatabaseAPI):
+    @abstractmethod
+    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
         ...

--- a/eth_enr/constants.py
+++ b/eth_enr/constants.py
@@ -1,13 +1,18 @@
 IDENTITY_SCHEME_ENR_KEY = b"id"
 ENR_REPR_PREFIX = "enr:"  # prefix used when printing an ENR
 MAX_ENR_SIZE = 300  # maximum allowed size of an ENR
+
+V4 = b"v4"
+V4_SIGNATURE_KEY = b"secp256k1"
+
 IP_V4_ADDRESS_ENR_KEY = b"ip"
 IP_V6_ADDRESS_ENR_KEY = b"ip6"
 UDP_PORT_ENR_KEY = b"udp"
 TCP_PORT_ENR_KEY = b"tcp"
 
-V4 = b"v4"
-V4_SIGNATURE_KEY = b"secp256k1"
+IP_V6_ADDRESS_ENR_KEY = b"ip6"
+UDP6_PORT_ENR_KEY = b"udp6"
+TCP6_PORT_ENR_KEY = b"tcp6"
 
 IP_V4_SIZE = 4  # size of an IPv4 address
 IP_V6_SIZE = 16  # size of an IPv6 address

--- a/eth_enr/constraints.py
+++ b/eth_enr/constraints.py
@@ -2,6 +2,17 @@ from eth_enr.abc import ConstraintAPI
 
 
 class KeyExists(ConstraintAPI):
+    """
+    Constrains ENR database queries to records which have a specified key.
+
+    .. code-block:: python
+
+        >>> enr_db = ...
+        >>> from eth_enr.constraints import KeyExists
+        >>> for enr in enr_db.query(KeyExists(b"some-key")):
+        ...     print("ENR: ", enr)
+    """
+
     key: bytes
 
     def __init__(self, key: bytes) -> None:
@@ -9,18 +20,66 @@ class KeyExists(ConstraintAPI):
 
 
 class HasUDPIPv4Endpoint(ConstraintAPI):
+    """
+    Constrains ENR database queries to records which have both the ``"ip"`` and
+    ``"udp"`` keys.
+
+    .. code-block:: python
+
+        >>> enr_db = ...
+        >>> from eth_enr.constraints import has_udp_ipv4_endpoint
+        >>> for enr in enr_db.query(has_udp_ipv4_endpoint):
+        ...     print("ENR: ", enr)
+    """
+
     pass
 
 
 class HasTCPIPv4Endpoint(ConstraintAPI):
+    """
+    Constrains ENR database queries to records which have both the ``"ip"`` and
+    ``"tcp"`` keys.
+
+    .. code-block:: python
+
+        >>> enr_db = ...
+        >>> from eth_enr.constraints import has_tcp_ipv4_endpoint
+        >>> for enr in enr_db.query(has_tcp_ipv4_endpoint):
+        ...     print("ENR: ", enr)
+    """
+
     pass
 
 
 class HasUDPIPv6Endpoint(ConstraintAPI):
+    """
+    Constrains ENR database queries to records which have both the ``"ip6"`` and
+    ``"udp6"`` keys.
+
+    .. code-block:: python
+
+        >>> enr_db = ...
+        >>> from eth_enr.constraints import has_udp_ipv6_endpoint
+        >>> for enr in enr_db.query(has_udp_ipv6_endpoint):
+        ...     print("ENR: ", enr)
+    """
+
     pass
 
 
 class HasTCPIPv6Endpoint(ConstraintAPI):
+    """
+    Constrains ENR database queries to records which have both the ``"ip6"`` and
+    ``"tcp6"`` keys.
+
+    .. code-block:: python
+
+        >>> enr_db = ...
+        >>> from eth_enr.constraints import has_tcp_ipv6_endpoint
+        >>> for enr in enr_db.query(has_tcp_ipv6_endpoint):
+        ...     print("ENR: ", enr)
+    """
+
     pass
 
 

--- a/eth_enr/constraints.py
+++ b/eth_enr/constraints.py
@@ -1,0 +1,30 @@
+from eth_enr.abc import ConstraintAPI
+
+
+class KeyExists(ConstraintAPI):
+    key: bytes
+
+    def __init__(self, key: bytes) -> None:
+        self.key = key
+
+
+class HasUDPIPv4Endpoint(ConstraintAPI):
+    pass
+
+
+class HasTCPIPv4Endpoint(ConstraintAPI):
+    pass
+
+
+class HasUDPIPv6Endpoint(ConstraintAPI):
+    pass
+
+
+class HasTCPIPv6Endpoint(ConstraintAPI):
+    pass
+
+
+has_tcp_ipv4_endpoint = HasTCPIPv4Endpoint()
+has_tcp_ipv6_endpoint = HasTCPIPv6Endpoint()
+has_udp_ipv4_endpoint = HasUDPIPv4Endpoint()
+has_udp_ipv6_endpoint = HasUDPIPv6Endpoint()

--- a/eth_enr/enr_db.py
+++ b/eth_enr/enr_db.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Iterable, MutableMapping, Optional
+from typing import MutableMapping, Optional
 
 from eth_typing import NodeID
 import rlp
 
 from eth_enr import ENR
-from eth_enr.abc import ENRAPI, ConstraintAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.abc import ENRAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
 from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
 from eth_enr.identity_schemes import default_identity_scheme_registry
 
@@ -61,6 +61,3 @@ class ENRDB(ENRDatabaseAPI):
 
     def _get_enr_key(self, node_id: NodeID) -> bytes:
         return bytes(node_id) + b":enr"
-
-    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
-        raise NotImplementedError

--- a/eth_enr/enr_db.py
+++ b/eth_enr/enr_db.py
@@ -1,11 +1,11 @@
 import logging
-from typing import MutableMapping, Optional
+from typing import Iterable, MutableMapping, Optional
 
 from eth_typing import NodeID
 import rlp
 
 from eth_enr import ENR
-from eth_enr.abc import ENRAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.abc import ENRAPI, ConstraintAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
 from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
 from eth_enr.identity_schemes import default_identity_scheme_registry
 
@@ -61,3 +61,6 @@ class ENRDB(ENRDatabaseAPI):
 
     def _get_enr_key(self, node_id: NodeID) -> bytes:
         return bytes(node_id) + b":enr"
+
+    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
+        raise NotImplementedError

--- a/eth_enr/query_db.py
+++ b/eth_enr/query_db.py
@@ -1,0 +1,114 @@
+import logging
+import sqlite3
+from typing import Iterable
+
+from eth_typing import NodeID
+from eth_utils import to_tuple
+
+from eth_enr.abc import ENRAPI, ConstraintAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.constants import (
+    IP_V4_ADDRESS_ENR_KEY,
+    IP_V6_ADDRESS_ENR_KEY,
+    TCP6_PORT_ENR_KEY,
+    TCP_PORT_ENR_KEY,
+    UDP6_PORT_ENR_KEY,
+    UDP_PORT_ENR_KEY,
+)
+from eth_enr.constraints import (
+    HasTCPIPv4Endpoint,
+    HasTCPIPv6Endpoint,
+    HasUDPIPv4Endpoint,
+    HasUDPIPv6Endpoint,
+    KeyExists,
+)
+from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
+from eth_enr.identity_schemes import default_identity_scheme_registry
+from eth_enr.sqlite3_db import (
+    Record,
+    RecordNotFound,
+    create_tables,
+    delete_record,
+    get_record,
+    insert_record,
+    query_records,
+)
+
+
+@to_tuple
+def _get_required_keys(*constraints: ConstraintAPI) -> Iterable[bytes]:
+    for constraint in constraints:
+        if isinstance(constraint, KeyExists):
+            yield constraint.key
+        elif isinstance(constraint, HasTCPIPv4Endpoint):
+            yield IP_V4_ADDRESS_ENR_KEY
+            yield TCP_PORT_ENR_KEY
+        elif isinstance(constraint, HasTCPIPv6Endpoint):
+            yield IP_V6_ADDRESS_ENR_KEY
+            yield TCP6_PORT_ENR_KEY
+        elif isinstance(constraint, HasUDPIPv4Endpoint):
+            yield IP_V4_ADDRESS_ENR_KEY
+            yield UDP_PORT_ENR_KEY
+        elif isinstance(constraint, HasUDPIPv6Endpoint):
+            yield IP_V6_ADDRESS_ENR_KEY
+            yield UDP6_PORT_ENR_KEY
+        else:
+            raise TypeError(f"Unsupported constraint type: {type(constraint)}")
+
+
+class QueryableENRDB(ENRDatabaseAPI):
+    logger = logging.getLogger("eth_enr.ENRDB")
+
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        identity_scheme_registry: IdentitySchemeRegistryAPI = default_identity_scheme_registry,
+    ) -> None:
+        self.connection = connection
+        self._identity_scheme_registry = identity_scheme_registry
+
+        create_tables(self.connection)
+
+    @property
+    def identity_scheme_registry(self) -> IdentitySchemeRegistryAPI:
+        return self._identity_scheme_registry
+
+    def _validate_identity_scheme(self, enr: ENRAPI) -> None:
+        """
+        Check that we know the identity scheme of the ENR.
+
+        This check should be performed whenever an ENR is inserted or updated in serialized form to
+        make sure retrieving it at a later time will succeed (deserializing the ENR would fail if
+        we don't know the identity scheme).
+        """
+        if enr.identity_scheme.id not in self.identity_scheme_registry:
+            raise UnknownIdentityScheme(
+                f"ENRs identity scheme with id {enr.identity_scheme.id!r} unknown to ENR DBs "
+                f"identity scheme registry"
+            )
+
+    def set_enr(self, enr: ENRAPI) -> None:
+        record = Record.from_enr(enr)
+
+        try:
+            insert_record(self.connection, record)
+        except sqlite3.IntegrityError:
+            raise OldSequenceNumber(enr.sequence_number)
+
+    def get_enr(self, node_id: NodeID) -> ENRAPI:
+        try:
+            record = get_record(self.connection, node_id)
+        except RecordNotFound:
+            raise KeyError(node_id)
+
+        return record.to_enr()
+
+    def delete_enr(self, node_id: NodeID) -> None:
+        deleted_rows = delete_record(self.connection, node_id)
+
+        if not deleted_rows:
+            raise KeyError(node_id)
+
+    def query(self, *constraints: ConstraintAPI) -> Iterable[ENRAPI]:
+        required_keys = _get_required_keys(*constraints)
+        for record in query_records(self.connection, required_keys=required_keys):
+            yield record.to_enr()

--- a/eth_enr/sqlite3_db.py
+++ b/eth_enr/sqlite3_db.py
@@ -1,0 +1,334 @@
+import datetime
+import logging
+import operator
+import sqlite3
+from typing import Collection, Iterable, NamedTuple, Tuple, Union
+
+from eth_typing import NodeID
+import rlp
+from rlp.exceptions import DecodingError, DeserializationError, SerializationError
+
+from eth_enr.abc import ENRAPI
+from eth_enr.enr import ENR
+from eth_enr.sedes import ENR_KEY_SEDES_MAPPING
+
+logger = logging.getLogger("eth_enr.sqlite3")
+
+RECORD_CREATE_STATEMENT = """CREATE TABLE record (
+    node_id BLOB NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    signature BLOB NOT NULL,
+    created_at DATETIME NOT NULL,
+    PRIMARY KEY (node_id, sequence_number),
+    CONSTRAINT _sequence_number_positive CHECK (sequence_number >= 0)
+)
+"""
+
+RECORD_INDEXES_AND_CONSTRAINTS = (
+    "CREATE UNIQUE INDEX ix_node_id_sequence_number ON record (node_id, sequence_number)",
+)
+
+FIELD_CREATE_STATEMENT = """CREATE TABLE field (
+    node_id BLOB NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    "key" BLOB NOT NULL,
+    value BLOB NOT NULL,
+    PRIMARY KEY (node_id, sequence_number, "key"),
+    CONSTRAINT uix_node_id_key UNIQUE (node_id, sequence_number, "key"),
+    FOREIGN KEY(node_id) REFERENCES record (node_id),
+    FOREIGN KEY(sequence_number) REFERENCES record (sequence_number)
+)
+"""
+
+FIELD_INDEXES_AND_CONSTRAINTS = (
+    'CREATE UNIQUE INDEX ix_node_id_sequence_number_key ON field (node_id, sequence_number, "key")',  # noqa: E501
+)
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    record_table_exists = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", ("record",)
+        ).fetchone()
+        is not None
+    )
+    field_table_exists = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", ("field",)
+        ).fetchone()
+        is not None
+    )
+
+    if record_table_exists and field_table_exists:
+        return
+
+    with conn:
+        conn.execute(RECORD_CREATE_STATEMENT)
+        conn.commit()
+        for statement in RECORD_INDEXES_AND_CONSTRAINTS:
+            conn.execute(statement)
+            conn.commit()
+
+        conn.execute(FIELD_CREATE_STATEMENT)
+        conn.commit()
+        for statement in FIELD_INDEXES_AND_CONSTRAINTS:
+            conn.execute(statement)
+            conn.commit()
+
+
+def _encode_enr_value(key: bytes, value: Union[int, bytes]) -> bytes:
+    try:
+        sedes = ENR_KEY_SEDES_MAPPING[key]
+    except KeyError:
+        if isinstance(value, bytes):
+            return value
+        else:
+            raise TypeError(f"Cannot store non-bytes value: {type(value)}")
+    else:
+        try:
+            return rlp.encode(value, sedes=sedes)  # type: ignore
+        except SerializationError:
+            if isinstance(value, bytes):
+                return value
+            else:
+                raise
+
+
+def _decode_enr_value(key: bytes, raw: bytes) -> Union[int, bytes]:
+    try:
+        sedes = ENR_KEY_SEDES_MAPPING[key]
+    except KeyError:
+        return raw
+    else:
+        try:
+            return rlp.decode(raw, sedes=sedes)  # type: ignore
+        except (DeserializationError, DecodingError):
+            return raw
+
+
+class Field(NamedTuple):
+    node_id: NodeID
+    sequence_number: int
+    key: bytes
+    value: bytes
+
+    @classmethod
+    def from_row(cls, row: Tuple[bytes, int, bytes, bytes]) -> "Field":
+        (
+            raw_node_id,
+            sequence_number,
+            key,
+            value,
+        ) = row
+        return cls(
+            node_id=NodeID(raw_node_id),
+            sequence_number=sequence_number,
+            key=key,
+            value=value,
+        )
+
+    def to_database_params(self) -> Tuple[NodeID, int, bytes, bytes]:
+        return (
+            self.node_id,
+            self.sequence_number,
+            self.key,
+            self.value,
+        )
+
+
+DB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+
+
+class Record(NamedTuple):
+    node_id: NodeID
+    sequence_number: int
+    signature: bytes
+
+    created_at: datetime.datetime
+
+    fields: Tuple[Field, ...]
+
+    @classmethod
+    def from_enr(cls, enr: ENRAPI) -> "Record":
+        fields = tuple(
+            sorted(
+                (
+                    Field(
+                        node_id=enr.node_id,
+                        sequence_number=enr.sequence_number,
+                        key=key,
+                        value=_encode_enr_value(key, value),
+                    )
+                    for key, value in enr.items()
+                ),
+                key=operator.attrgetter("key"),
+            )
+        )
+        return cls(
+            node_id=enr.node_id,
+            sequence_number=enr.sequence_number,
+            signature=enr.signature,
+            created_at=datetime.datetime.utcnow(),
+            fields=fields,
+        )
+
+    def to_enr(self) -> ENRAPI:
+        kv_pairs = {
+            field.key: _decode_enr_value(field.key, field.value)
+            for field in self.fields
+        }
+        return ENR(
+            sequence_number=self.sequence_number,
+            kv_pairs=kv_pairs,
+            signature=self.signature,
+        )
+
+    @classmethod
+    def from_row(
+        cls, row: Tuple[bytes, int, bytes, str], fields: Collection[Field]
+    ) -> "Record":
+        (
+            raw_node_id,
+            sequence_number,
+            signature,
+            raw_created_at,
+        ) = row
+        return cls(
+            node_id=NodeID(raw_node_id),
+            sequence_number=sequence_number,
+            signature=signature,
+            created_at=datetime.datetime.strptime(raw_created_at, DB_DATETIME_FORMAT),
+            fields=tuple(sorted(fields, key=operator.attrgetter("key"))),
+        )
+
+    def to_database_params(self) -> Tuple[NodeID, int, bytes, str]:
+        return (
+            self.node_id,
+            self.sequence_number,
+            self.signature,
+            self.created_at.isoformat(sep=" "),
+        )
+
+
+RECORD_INSERT_QUERY = "INSERT INTO record (node_id, sequence_number, signature, created_at) VALUES (?, ?, ?, ?)"  # noqa: E501
+
+FIELD_INSERT_QUERY = (
+    'INSERT INTO field (node_id, sequence_number, "key", value) VALUES (?, ?, ?, ?)'
+)
+
+
+def insert_record(conn: sqlite3.Connection, record: Record) -> None:
+    with conn:
+        conn.execute(RECORD_INSERT_QUERY, record.to_database_params())
+        field_params = tuple(field.to_database_params() for field in record.fields)
+        conn.executemany(FIELD_INSERT_QUERY, field_params)
+
+
+RECORD_GET_QUERY = """SELECT
+    record.node_id AS record_node_id,
+    record.sequence_number AS record_sequence_number,
+    record.signature AS record_signature,
+    record.created_at AS record_created_at
+
+    FROM record
+    WHERE record.node_id = ? ORDER BY record.sequence_number DESC
+    LIMIT ? OFFSET ?
+"""
+
+
+FIELD_GET_QUERY = """SELECT
+    field.node_id AS field_node_id,
+    field.sequence_number AS field_sequence_number,
+    field."key" AS field_key,
+    field.value AS field_value
+
+    FROM field
+    WHERE ? = field.node_id AND ? = field.sequence_number
+"""
+
+
+class RecordNotFound(Exception):
+    pass
+
+
+def get_record(conn: sqlite3.Connection, node_id: NodeID) -> Record:
+    record_row = conn.execute(RECORD_GET_QUERY, (node_id, 1, 0)).fetchone()
+    if record_row is None:
+        raise RecordNotFound(f"No record found: node_id={node_id.hex()}")
+    field_rows = conn.execute(FIELD_GET_QUERY, (node_id, record_row[1])).fetchall()
+
+    fields = tuple(Field.from_row(row) for row in field_rows)
+    record = Record.from_row(row=record_row, fields=fields)
+    return record
+
+
+DELETE_RECORD_QUERY = """DELETE FROM record WHERE record.node_id = ?"""
+DELETE_FIELD_QUERY = """DELETE FROM field WHERE field.node_id = ?"""
+
+
+def delete_record(conn: sqlite3.Connection, node_id: NodeID) -> int:
+    with conn:
+        cursor = conn.execute(DELETE_RECORD_QUERY, (node_id,))
+        conn.execute(DELETE_FIELD_QUERY, (node_id,))
+    return cursor.rowcount  # type: ignore
+
+
+BASE_QUERY = """SELECT
+    record.node_id AS record_node_id,
+    record.sequence_number AS record_sequence_number,
+    record.signature AS record_signature,
+    record.created_at AS record_created_at
+    FROM record
+    INNER JOIN (
+        SELECT
+            record.node_id,
+            record.sequence_number,
+            MAX(record.sequence_number)
+        FROM record
+        GROUP BY record.node_id
+    ) latest_record
+        ON
+            record.node_id == latest_record.node_id AND
+            record.sequence_number == latest_record.sequence_number
+    JOIN field
+        ON
+            record.node_id = field.node_id AND
+            record.sequence_number = field.sequence_number
+    {where_statements}
+    GROUP BY record.node_id
+"""
+
+
+EXISTS_CLAUSE = """EXISTS (
+    SELECT 1
+    FROM field
+    WHERE
+        record.node_id = field.node_id
+        AND record.sequence_number = field.sequence_number AND field."key" = ?
+)
+"""
+
+
+def query_records(
+    conn: sqlite3.Connection, required_keys: Collection[bytes] = ()
+) -> Iterable[Record]:
+    num_required_keys = len(required_keys)
+
+    if num_required_keys == 0:
+        query = BASE_QUERY.format(where_statements="")
+    elif num_required_keys == 1:
+        query = BASE_QUERY.format(where_statements=f"WHERE {EXISTS_CLAUSE}")
+    else:
+        query_components = tuple([f"({EXISTS_CLAUSE})"] * num_required_keys)
+        combined_query_components = " AND ".join(query_components)
+        query = BASE_QUERY.format(where_statements=f"WHERE {combined_query_components}")
+
+    logger.debug("query_records: query=%s  params=%r", query, required_keys)
+
+    for record_row in conn.execute(query, required_keys):
+        record_row = record_row[:4]
+        field_rows = conn.execute(FIELD_GET_QUERY, (record_row[0], record_row[1]))
+
+        fields = tuple(Field.from_row(row) for row in field_rows.fetchall())
+        record = Record.from_row(record_row, fields=fields)
+        yield record

--- a/eth_enr/tools/factories.py
+++ b/eth_enr/tools/factories.py
@@ -8,8 +8,12 @@ from eth_keys import keys
 from eth_utils import int_to_big_endian
 from eth_utils.toolz import merge
 import factory
+from faker import Faker
 
+from eth_enr.abc import ENRAPI
 from eth_enr.enr import ENR, UnsignedENR
+from eth_enr.enr_db import ENRDB
+from eth_enr.enr_manager import ENRManager
 from eth_enr.identity_schemes import V4IdentityScheme
 
 
@@ -107,3 +111,31 @@ class ENRFactory(factory.Factory):  # type: ignore
         private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
         address = factory.SubFactory(AddressFactory)
         custom_kv_pairs: Dict[bytes, Any] = {}
+
+    @classmethod
+    def minimal(cls) -> ENRAPI:
+        private_key = PrivateKeyFactory()
+        kv_pairs = {
+            b"id": b"v4",
+            b"secp256k1": private_key.public_key.to_compressed_bytes(),
+        }
+        return cls(private_key=private_key.to_bytes(), kv_pairs=kv_pairs)
+
+
+_faker = Faker()
+
+
+def IPv6Factory() -> ipaddress.IPv6Address:
+    return ipaddress.IPv6Address(_faker.ipv6())
+
+
+def IPv4Factory() -> ipaddress.IPv4Address:
+    return ipaddress.IPv4Address(_faker.ipv4())
+
+
+class ENRManagerFactory(factory.Factory):  # type: ignore
+    private_key = factory.SubFactory(PrivateKeyFactory)
+    enr_db = factory.LazyFunction(lambda: ENRDB({}))
+
+    class Meta:
+        model = ENRManager

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,21 @@
+import sqlite3
+
+import pytest
+
+from eth_enr.sqlite3_db import create_tables
+
+
+@pytest.fixture
+def base_conn():
+    return sqlite3.connect(":memory:")
+
+
+@pytest.fixture
+def conn(base_conn):
+    create_tables(base_conn)
+    return base_conn
+
+
+@pytest.fixture
+def cursor(conn):
+    return conn.cursor()

--- a/tests/core/test_enr_db.py
+++ b/tests/core/test_enr_db.py
@@ -3,12 +3,19 @@ import pytest
 from eth_enr.enr_db import ENRDB
 from eth_enr.exceptions import OldSequenceNumber, UnknownIdentityScheme
 from eth_enr.identity_schemes import IdentitySchemeRegistry
+from eth_enr.query_db import QueryableENRDB
 from eth_enr.tools.factories import ENRFactory, PrivateKeyFactory
 
 
-@pytest.fixture
-def enr_db():
-    return ENRDB({})
+@pytest.fixture(params=("mapping", "orm"))
+def enr_db(request):
+    if request.param == "mapping":
+        return ENRDB({})
+    elif request.param == "orm":
+        conn = request.getfixturevalue("conn")
+        return QueryableENRDB(conn)
+    else:
+        raise Exception(f"Unsupported param: {request.param}")
 
 
 def test_checks_identity_scheme():

--- a/tests/core/test_enr_db_query.py
+++ b/tests/core/test_enr_db_query.py
@@ -1,0 +1,198 @@
+import pytest
+
+from eth_enr.constants import (
+    IP_V4_ADDRESS_ENR_KEY,
+    IP_V6_ADDRESS_ENR_KEY,
+    TCP6_PORT_ENR_KEY,
+    TCP_PORT_ENR_KEY,
+    UDP6_PORT_ENR_KEY,
+    UDP_PORT_ENR_KEY,
+)
+from eth_enr.constraints import (
+    KeyExists,
+    has_tcp_ipv4_endpoint,
+    has_tcp_ipv6_endpoint,
+    has_udp_ipv4_endpoint,
+    has_udp_ipv6_endpoint,
+)
+from eth_enr.enr import ENR
+from eth_enr.query_db import QueryableENRDB
+from eth_enr.tools.factories import (
+    ENRFactory,
+    ENRManagerFactory,
+    IPv4Factory,
+    IPv6Factory,
+    PrivateKeyFactory,
+)
+
+
+@pytest.fixture
+def enr_db(conn):
+    return QueryableENRDB(conn)
+
+
+def test_query_with_empty_database(enr_db):
+    assert not tuple(enr_db.query(KeyExists(b"nope")))
+    assert not tuple(enr_db.query())
+
+
+def test_query_by_key_existence(enr_db):
+    enr_a = ENRFactory(custom_kv_pairs={b"test": b"value-A"})
+    enr_b = ENRFactory(custom_kv_pairs={b"test": b"value-B"})
+    enr_c = ENRFactory()
+
+    enr_db.set_enr(enr_a)
+    enr_db.set_enr(enr_b)
+    enr_db.set_enr(enr_c)
+
+    enr_results = set(enr_db.query(KeyExists(b"test")))
+    assert len(enr_results) == 2
+
+    assert enr_a in enr_results
+    assert enr_b in enr_results
+    assert enr_c not in enr_results
+
+
+def test_query_with_enr_sequence_number_zero(enr_db):
+    enr = ENR.from_repr(
+        "enr:-Ji4QEdP7fMAICGFlUAxY2cbTYXbPImZzMoKHFyssXNz7zWRNkFZ7Q4EJo3rZsDUVbyo5e_d-zBIDCUHgq72oEIokSaAgmlkgnY0gmlwhMCzfZuJc2VjcDI1NmsxoQNCiVGdz4CJY3sD7bHTrhPcgOu18gfMuyc6kgicqYR_0YN0Y3CC192EdGVzdId2YWx1ZS1Bg3VkcIK0fw"  # noqa: E501
+    )
+
+    assert b"test" in enr
+    assert enr.sequence_number == 0
+
+    enr_db.set_enr(enr)
+
+    enr_results = set(enr_db.query(KeyExists(b"test")))
+    assert len(enr_results) == 1
+
+    assert enr in enr_results
+
+
+def test_query_only_returns_latest_record(enr_db):
+    private_key_a = PrivateKeyFactory().to_bytes()
+
+    enr_a_0 = ENRFactory(sequence_number=0, private_key=private_key_a)
+    enr_a_7 = ENRFactory(sequence_number=7, private_key=private_key_a)
+
+    private_key_b = PrivateKeyFactory().to_bytes()
+
+    enr_b_1 = ENRFactory(sequence_number=1, private_key=private_key_b)
+    enr_b_9 = ENRFactory(sequence_number=9, private_key=private_key_b)
+
+    enr_db.set_enr(enr_a_0)
+    enr_db.set_enr(enr_a_7)
+
+    enr_db.set_enr(enr_b_1)
+    enr_db.set_enr(enr_b_9)
+
+    enr_results = set(enr_db.query())
+    assert len(enr_results) == 2
+
+    assert enr_a_7 in enr_results
+    assert enr_b_9 in enr_results
+
+
+def test_query_excludes_outdated_matching_records(enr_db):
+    private_key_a = PrivateKeyFactory().to_bytes()
+
+    enr_a_0 = ENRFactory(
+        sequence_number=0,
+        private_key=private_key_a,
+        custom_kv_pairs={b"test": b"value-A"},
+    )
+    enr_a_7 = ENRFactory(sequence_number=7, private_key=private_key_a)
+
+    private_key_b = PrivateKeyFactory().to_bytes()
+
+    enr_b_1 = ENRFactory(
+        sequence_number=1,
+        private_key=private_key_b,
+        custom_kv_pairs={b"test": b"value-A"},
+    )
+
+    enr_db.set_enr(enr_a_0)
+    enr_db.set_enr(enr_a_7)
+
+    enr_db.set_enr(enr_b_1)
+
+    enr_results = tuple(enr_db.query(KeyExists(b"test")))
+    assert len(enr_results) == 1
+
+    enr = enr_results[0]
+    assert enr == enr_b_1
+
+
+@pytest.mark.parametrize("constraint", (has_tcp_ipv4_endpoint, has_udp_ipv4_endpoint))
+def test_query_for_ipv4_endpoint(enr_db, constraint):
+    # doesn't have either key
+    enr_a = ENRFactory.minimal()
+    # two have the correct keys
+    enr_b = ENRFactory()
+    enr_c = ENRFactory()
+
+    # missing port
+    enr_d_manager = ENRManagerFactory()
+    enr_d_manager.update((IP_V4_ADDRESS_ENR_KEY, IPv4Factory().packed))
+
+    enr_d = enr_d_manager.enr
+
+    # missing ip address
+    enr_e_manager = ENRManagerFactory()
+    enr_e_manager.update((UDP_PORT_ENR_KEY, 30303))
+    enr_e_manager.update((TCP_PORT_ENR_KEY, 30303))
+
+    enr_e = enr_e_manager.enr
+
+    enr_db.set_enr(enr_a)
+    enr_db.set_enr(enr_b)
+    enr_db.set_enr(enr_c)
+    enr_db.set_enr(enr_d)
+    enr_db.set_enr(enr_e)
+
+    enr_results = tuple(enr_db.query(constraint))
+    assert len(enr_results) == 2
+
+    assert set(enr_results) == {enr_b, enr_c}
+
+
+@pytest.mark.parametrize("constraint", (has_tcp_ipv6_endpoint, has_udp_ipv6_endpoint))
+def test_query_for_ipv6_endpoint(enr_db, constraint):
+    ip6 = IPv6Factory()
+
+    # missing both keys
+    enr_a = ENRFactory.minimal()
+
+    # has both
+    enr_b = ENRFactory(
+        custom_kv_pairs={
+            b"ip6": ip6.packed,
+            b"tcp6": 30303,
+            b"udp6": 30303,
+        }
+    )
+
+    # missing port
+    enr_c_manager = ENRManagerFactory()
+    enr_c_manager.update((IP_V6_ADDRESS_ENR_KEY, ip6.packed))
+
+    enr_c = enr_c_manager.enr
+
+    # missing ip address
+    enr_d_manager = ENRManagerFactory()
+    enr_d_manager.update((UDP6_PORT_ENR_KEY, 30303))
+    enr_d_manager.update((TCP6_PORT_ENR_KEY, 30303))
+
+    enr_d = enr_d_manager.enr
+
+    enr_db.set_enr(enr_a)
+    enr_db.set_enr(enr_b)
+    enr_db.set_enr(enr_c)
+    enr_db.set_enr(enr_d)
+
+    enr_results = tuple(enr_db.query(constraint))
+    assert len(enr_results) == 1
+
+    enr = enr_results[0]
+
+    assert enr == enr_b

--- a/tests/core/test_sqlite3_db.py
+++ b/tests/core/test_sqlite3_db.py
@@ -1,0 +1,202 @@
+import datetime
+import sqlite3
+
+import pytest
+
+from eth_enr.enr import ENR
+from eth_enr.sqlite3_db import (
+    Record,
+    RecordNotFound,
+    create_tables,
+    delete_record,
+    get_record,
+    insert_record,
+    query_records,
+)
+from eth_enr.tools.factories import ENRFactory
+
+
+def test_database_initialization():
+    conn = sqlite3.connect(":memory:")
+
+    assert (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", ("record",)
+        ).fetchone()
+        is None
+    )
+    assert (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", ("field",)
+        ).fetchone()
+        is None
+    )
+
+    create_tables(conn)
+
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", ("record",)
+    ).fetchone() == ("record",)
+    assert conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", ("field",)
+    ).fetchone() == ("field",)
+
+
+def test_record_insert_and_retrieval(conn):
+    enr = ENRFactory()
+    record = Record.from_enr(enr)
+    insert_record(conn, record)
+    result = get_record(conn, enr.node_id)
+    assert result == record
+
+
+def test_record_get_with_unknown_node_id(conn):
+    enr = ENRFactory()
+    with pytest.raises(RecordNotFound):
+        get_record(conn, enr.node_id)
+
+
+def test_record_duplicate_insert(conn):
+    enr = ENRFactory()
+    record = Record.from_enr(enr)
+    insert_record(conn, record)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        insert_record(conn, record)
+
+    dup_record = Record(
+        node_id=record.node_id,
+        sequence_number=record.sequence_number,
+        signature=record.signature,
+        created_at=datetime.datetime.utcnow(),
+        fields=record.fields,
+    )
+    assert dup_record != record
+
+    with pytest.raises(sqlite3.IntegrityError):
+        insert_record(conn, dup_record)
+
+
+def test_record_deletion(conn):
+    record = Record.from_enr(ENRFactory())
+    insert_record(conn, record)
+    assert get_record(conn, record.node_id) == record
+
+    row_count = delete_record(conn, record.node_id)
+    assert row_count == 1
+
+    with pytest.raises(RecordNotFound):
+        get_record(conn, record.node_id)
+
+
+def test_record_query_with_no_constraints(conn):
+    record_a = Record.from_enr(ENRFactory())
+    record_b = Record.from_enr(ENRFactory())
+
+    insert_record(conn, record_a)
+    insert_record(conn, record_b)
+
+    all_records = tuple(query_records(conn))
+    assert set(all_records) == {record_a, record_b}
+
+
+def test_record_query_with_enr_sequence_zero(conn):
+    # This is more of a regression test.  Previously the SQL query used a
+    # HAVING clause which didn't work correctly when the only record had a
+    # sequence number of 0.
+    enr = ENR.from_repr(
+        "enr:-Ji4QEdP7fMAICGFlUAxY2cbTYXbPImZzMoKHFyssXNz7zWRNkFZ7Q4EJo3rZsDUVbyo5e_d-zBIDCUHgq72oEIokSaAgmlkgnY0gmlwhMCzfZuJc2VjcDI1NmsxoQNCiVGdz4CJY3sD7bHTrhPcgOu18gfMuyc6kgicqYR_0YN0Y3CC192EdGVzdId2YWx1ZS1Bg3VkcIK0fw"  # noqa: E501
+    )
+    record = Record.from_enr(enr)
+    insert_record(conn, record)
+    assert get_record(conn, record.node_id) == record
+
+    assert b"test" in enr
+
+    results = tuple(query_records(conn, required_keys=(b"test",)))
+
+    assert len(results) == 1
+    assert results[0] == record
+
+
+def test_record_query_with_key_present_in_earlier_record(conn):
+    # Demonstrate that when we have an *outdated* record with the given key
+    # that it doesn't get returned in the query
+    enr_0 = ENR.from_repr(
+        "enr:-Ji4QP4nHj12UZ8um1c9pplfNYzD7tmDKm5zjWXAQbtvaHQGHYfgHPBNMqPrKjkw1vPnzhxTxYvKxQaYsTsr8tXuG-aAgmlkgnY0gmlwhFIKDgiJc2VjcDI1NmsxoQLBnsAJ3ol6-WoC_oldxmv85K9CVaIxFD1U1qY5ik9-7YN0Y3CCme-EdGVzdId2YWx1ZS1Bg3VkcILjVw"  # noqa: E501
+    )
+    enr_7 = ENR.from_repr(
+        "enr:-Iu4QAEoWs6MtSYdWONcnR7ekG2lunNxxVlg_xgTKzAUTJDLeqQo06oKbnesHUBl77IFzlnj_GcoYNVnM13ap0i3GAYHgmlkgnY0gmlwhDN7BECJc2VjcDI1NmsxoQLBnsAJ3ol6-WoC_oldxmv85K9CVaIxFD1U1qY5ik9-7YN0Y3CCxMGDdWRwguHh"  # noqa: E501
+    )
+
+    assert enr_0.node_id == enr_7.node_id
+    assert enr_0.sequence_number == 0
+    assert enr_7.sequence_number == 7
+
+    assert b"test" in enr_0
+    assert b"test" not in enr_7
+
+    insert_record(conn, Record.from_enr(enr_0))
+    insert_record(conn, Record.from_enr(enr_7))
+
+    results = tuple(query_records(conn, required_keys=(b"test",)))
+
+    assert len(results) == 0
+
+
+def test_record_query_with_single_key_constraint(conn):
+    record_a = Record.from_enr(ENRFactory())
+    record_b = Record.from_enr(
+        ENRFactory(
+            custom_kv_pairs={b"test": b"value-A"},
+        )
+    )
+    record_c = Record.from_enr(ENRFactory())
+    record_d = Record.from_enr(
+        ENRFactory(
+            custom_kv_pairs={b"test": b"value-A"},
+        )
+    )
+
+    insert_record(conn, record_a)
+    insert_record(conn, record_b)
+    insert_record(conn, record_c)
+    insert_record(conn, record_d)
+
+    matched_records = tuple(query_records(conn, required_keys=(b"test",)))
+    assert len(matched_records) == 2
+    assert set(matched_records) == {record_b, record_d}
+
+
+def test_record_query_with_multi_key_constraint(conn):
+    record_a = Record.from_enr(
+        ENRFactory(
+            custom_kv_pairs={b"test-a": b"value-A"},
+        )
+    )
+    record_b = Record.from_enr(
+        ENRFactory(
+            custom_kv_pairs={b"test-a": b"value-A", b"test-b": b"value-B"},
+        )
+    )
+    record_c = Record.from_enr(
+        ENRFactory(
+            custom_kv_pairs={b"test-b": b"value-B"},
+        )
+    )
+    record_d = Record.from_enr(ENRFactory())
+    record_e = Record.from_enr(
+        ENRFactory(
+            custom_kv_pairs={b"test-a": b"value-A", b"test-b": b"value-B"},
+        )
+    )
+
+    insert_record(conn, record_a)
+    insert_record(conn, record_b)
+    insert_record(conn, record_c)
+    insert_record(conn, record_d)
+    insert_record(conn, record_e)
+
+    matched_records = tuple(query_records(conn, required_keys=(b"test-a", b"test-b")))
+    assert len(matched_records) == 2
+    assert set(matched_records) == {record_b, record_e}


### PR DESCRIPTION
## What was wrong?

One upcoming need for our Discovery v5 code is to be able to query our ENR database for records with a certain key or set of keys.  The current `ENRDatabaseAPI` doesn't support this.

## How was it fixed?

Defined a second database API: `QueryableENRDatabaseAPI` which supports an additional `query(*constraints)` function.

Implemented `QueryableENRDB` which implements the `QueryableENRDatabaseAPI` on top of a Sqlite3 database using the standard library `sqlite3` library.

#### Cute Animal Picture

![14-unlikely-animal-friends](https://user-images.githubusercontent.com/824194/96777512-a85c0080-13a7-11eb-8b25-076994dd8006.jpg)

