### PR TITLE
Add more useful ENR.__str__ implementation

### DIFF
--- a/eth_enr/constants.py
+++ b/eth_enr/constants.py
@@ -2,8 +2,12 @@ IDENTITY_SCHEME_ENR_KEY = b"id"
 ENR_REPR_PREFIX = "enr:"  # prefix used when printing an ENR
 MAX_ENR_SIZE = 300  # maximum allowed size of an ENR
 IP_V4_ADDRESS_ENR_KEY = b"ip"
+IP_V6_ADDRESS_ENR_KEY = b"ip6"
 UDP_PORT_ENR_KEY = b"udp"
 TCP_PORT_ENR_KEY = b"tcp"
+
+V4 = b"v4"
+V4_SIGNATURE_KEY = b"secp256k1"
 
 IP_V4_SIZE = 4  # size of an IPv4 address
 IP_V6_SIZE = 16  # size of an IPv6 address

--- a/eth_enr/identity_schemes.py
+++ b/eth_enr/identity_schemes.py
@@ -12,6 +12,7 @@ from eth_enr.abc import (
     IdentitySchemeAPI,
     IdentitySchemeRegistryAPI,
 )
+from eth_enr.constants import V4, V4_SIGNATURE_KEY
 
 
 class IdentitySchemeRegistry(IdentitySchemeRegistryAPI):
@@ -40,8 +41,8 @@ discv4_identity_scheme_registry = IdentitySchemeRegistry()
 @discv4_identity_scheme_registry.register
 class V4IdentityScheme(IdentitySchemeAPI):
 
-    id = b"v4"
-    public_key_enr_key = b"secp256k1"
+    id = V4
+    public_key_enr_key = V4_SIGNATURE_KEY
 
     private_key_size = 32
 


### PR DESCRIPTION
## What was wrong?

The output of `str(enr)` only gave the base64 encoded representation which tells you very little about the record.

## How was it fixed?

Added an `ENR.__str__` implementation which includes all of the ENR fields in human readable representations.


#### Cute Animal Picture

![unlikely-animal-friendships-4](https://user-images.githubusercontent.com/824194/96776070-b7da4a00-13a5-11eb-91e1-a25158ee9ce8.jpg)

