### PR TITLE
Handle ENR records with malformed values for standard keys

### DIFF
--- a/tests/core/test_enr_db.py
+++ b/tests/core/test_enr_db.py
@@ -40,6 +40,28 @@ def test_get_and_set_enr(enr_db):
         db.set_enr(enr)
 
 
+def test_get_and_set_enr_with_non_standard_values(enr_db):
+    custom_kv_pairs = {
+        b"ip": b"too-long-for-ipv4",
+        b"ip6": b"too-short",
+        b"udp": b"\x00\x01\x00",  # invalid encoding for an integer
+        b"tcp": b"\x00\x01\x00",  # invalid encoding for an integer
+        b"udp6": b"\x00\x01\x00",  # invalid encoding for an integer
+        b"tcp6": b"\x00\x01\x00",  # invalid encoding for an integer
+    }
+    enr = ENRFactory(
+        custom_kv_pairs=custom_kv_pairs,
+    )
+
+    for key, value in custom_kv_pairs.items():
+        assert enr[key] == value
+
+    enr_db.set_enr(enr)
+
+    result = enr_db.get_enr(enr.node_id)
+    assert result == enr
+
+
 def test_delete_enr(enr_db):
     db = enr_db
     enr = ENRFactory()


### PR DESCRIPTION
## What was wrong?

The `ENR` class treats a few keys as *special*.  Specifically `ip`, `ip6`, `udp`, `tcp, `udp6` and `tcp6`.  It tries to use *rich* values, decoding them as integers for the `tcp/udp` port numbers, and fixed size byte arrays for the `ip` and `ip6`.  There is nothing that requires these values be well formed for their rich implementations and we weren't handling this case correctly.

## How was it fixed?

Add fallback handling for these values and tests.


#### Cute Animal Picture

![elephant-dog](https://user-images.githubusercontent.com/824194/96776671-9332a200-13a6-11eb-9341-81dff6866fe5.jpeg)

