### PR TITLE
Add support for proximate queries

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -137,6 +137,12 @@ Constraints
     :show-inheritance:
 
 
+.. autoclass:: eth_enr.constraints.ClosestTo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Exceptions
 ----------
 

--- a/eth_enr/constraints.py
+++ b/eth_enr/constraints.py
@@ -1,3 +1,5 @@
+from eth_typing import NodeID
+
 from eth_enr.abc import ConstraintAPI
 
 
@@ -81,6 +83,25 @@ class HasTCPIPv6Endpoint(ConstraintAPI):
     """
 
     pass
+
+
+class ClosestTo(ConstraintAPI):
+    """
+    Constrains ENR database queries to return records proximate to a specific `node_id`
+
+    .. code-block:: python
+
+        >>> enr_db = ...
+        >>> node_id = ...
+        >>> from eth_enr.constraints import ClosestTo
+        >>> for enr in enr_db.query(ClosestTo(node_id)):
+        ...     print("ENR: ", enr)
+    """
+
+    node_id: NodeID
+
+    def __init__(self, node_id: NodeID) -> None:
+        self.node_id = node_id
 
 
 has_tcp_ipv4_endpoint = HasTCPIPv4Endpoint()


### PR DESCRIPTION
## What was wrong?

It is useful to be able to query ENR records by proximity to a certain `node_id`

## How was it fixed?

Added functionality to support querying by proximity to another `node_id`.

#### Cute Animal Picture

![1280-163639077-jumping-red-kangaroo](https://user-images.githubusercontent.com/824194/100017461-29882800-2d98-11eb-800f-00bd3a5702ab.jpg)

