### PR TITLE
fix abc for QueryableENRDatabaseAPI

### DIFF
--- a/eth_enr/__init__.py
+++ b/eth_enr/__init__.py
@@ -4,6 +4,7 @@ from eth_enr.abc import (  # noqa: F401
     ENRManagerAPI,
     IdentitySchemeAPI,
     IdentitySchemeRegistryAPI,
+    QueryableENRDatabaseAPI,
     UnsignedENRAPI,
 )
 from eth_enr.enr import ENR, UnsignedENR  # noqa: F401

--- a/eth_enr/query_db.py
+++ b/eth_enr/query_db.py
@@ -5,7 +5,12 @@ from typing import Iterable, Optional
 from eth_typing import NodeID
 from eth_utils import to_tuple
 
-from eth_enr.abc import ENRAPI, ConstraintAPI, ENRDatabaseAPI, IdentitySchemeRegistryAPI
+from eth_enr.abc import (
+    ENRAPI,
+    ConstraintAPI,
+    IdentitySchemeRegistryAPI,
+    QueryableENRDatabaseAPI,
+)
 from eth_enr.constants import (
     IP_V4_ADDRESS_ENR_KEY,
     IP_V6_ADDRESS_ENR_KEY,
@@ -72,7 +77,7 @@ def _get_order_closest_to(*constraints: ConstraintAPI) -> Optional[NodeID]:
         )
 
 
-class QueryableENRDB(ENRDatabaseAPI):
+class QueryableENRDB(QueryableENRDatabaseAPI):
     """
     An implementation of :class:`eth_enr.abc.QueryableENRDatabaseAPI` on top of
     the ``sqlite3`` module from the standard library.


### PR DESCRIPTION
## What was wrong?

ABC inheritance was missing for `QueryableENRDB -> QueryableENRDatabaseAPI`

## How was it fixed?

Changed the base class

#### Cute Animal Picture

![img_7052_apa_7757_600](https://user-images.githubusercontent.com/824194/100022712-e5e5ec00-2da0-11eb-90ea-c4504b7124bf.jpg)

