### PR TITLE
Update library exception behavior

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -153,6 +153,12 @@ Exceptions
     :show-inheritance:
 
 
+.. autoclass:: eth_enr.exceptions.DuplicateRecord
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 .. autoclass:: eth_enr.exceptions.UnknownIdentityScheme
     :members:
     :undoc-members:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -65,7 +65,7 @@ storage is flexible and accepts any dictionary-like object.
     ...     b'secp256k1': private_key.public_key.to_compressed_bytes(),
     ... }).to_signed_enr(private_key.to_bytes())
     >>> enr_db.set_enr(updated_enr)
-    >>> enr_db.set_enr(enr)  # throws exception due to old sequence number
+    >>> enr_db.set_enr(enr, raise_on_error=True)  # throws exception due to old sequence number
     Traceback (most recent call last):
       File "/home/piper/.pyenv/versions/3.6.9/lib/python3.6/doctest.py", line 1330, in __run
         compileflags, 1), test.globs)

--- a/eth_enr/abc.py
+++ b/eth_enr/abc.py
@@ -129,7 +129,7 @@ class IdentitySchemeAPI(ABC):
 
 class ENRDatabaseAPI(ABC):
     @abstractmethod
-    def set_enr(self, enr: ENRAPI) -> None:
+    def set_enr(self, enr: ENRAPI, raise_on_error: bool = False) -> None:
         ...
 
     @abstractmethod

--- a/eth_enr/exceptions.py
+++ b/eth_enr/exceptions.py
@@ -21,3 +21,12 @@ class OldSequenceNumber(BaseENRException):
     """
 
     pass
+
+
+class DuplicateRecord(BaseENRException):
+    """
+    Raised when trying to set an ENR record to a database that already has a
+    different record with the same sequence number.
+    """
+
+    pass


### PR DESCRIPTION
fixes #19 

## What was wrong?

The behavior of the two different databases when setting ENR records was inconsistent, and resulted in requiring boilerplate exception handling everywhere `set_enr` was used.

## How was it fixed?

The exception behavior is now roughly the same and more "sane".  Also, errors are now swollowed by default which is the standard way that the DDHT application behaves and is a reasonable standard for others to use.

#### Cute Animal Picture

![Desktop-fox-jump-winter-field-snow](https://user-images.githubusercontent.com/824194/100485604-ec84a400-30bd-11eb-8e9d-0dce48152877.jpg)
